### PR TITLE
Add ConfigService utility

### DIFF
--- a/lib/cucloud.rb
+++ b/lib/cucloud.rb
@@ -8,6 +8,7 @@ module Cucloud
   require 'cucloud/ssm_utils'
   require 'cucloud/iam_utils'
   require 'cucloud/vpc_utils'
+  require 'cucloud/config_service_utils'
 
   # This is the default region API calls are made against
   DEFAULT_REGION = 'us-east-1'.freeze

--- a/lib/cucloud/config_service_utils.rb
+++ b/lib/cucloud/config_service_utils.rb
@@ -19,7 +19,7 @@ module Cucloud
     end
 
     # Constructor for ConfigServiceUtilsclass
-    # @param asg_client [Aws::ConfigService::Client] AWS ConfigService SDK Client
+    # @param [Aws::ConfigService::Client] AWS ConfigService SDK Client
     def initialize(cs_client = Aws::ConfigService::Client.new)
       unless Cucloud::ConfigServiceUtils.get_available_regions.include? Cucloud.region
         raise Cucloud::ConfigServiceUtils::UnsupportedRegionError,

--- a/lib/cucloud/config_service_utils.rb
+++ b/lib/cucloud/config_service_utils.rb
@@ -21,7 +21,11 @@ module Cucloud
     # Constructor for ConfigServiceUtilsclass
     # @param asg_client [Aws::ConfigService::Client] AWS ConfigService SDK Client
     def initialize(cs_client = Aws::ConfigService::Client.new)
-      ## DI for testing purposes
+      unless Cucloud::ConfigServiceUtils.get_available_regions.include? Cucloud.region
+        raise Cucloud::ConfigServiceUtils::UnsupportedRegionError,
+              "Region #{Cucloud.region} not yet supported by config service"
+      end
+
       @cs = cs_client
       @region = Cucloud.region
     end

--- a/lib/cucloud/config_service_utils.rb
+++ b/lib/cucloud/config_service_utils.rb
@@ -50,7 +50,7 @@ module Cucloud
     # Get evaluation status of rule by name
     # @param [String] Rule name
     # @return [Types::ConfigRuleEvaluationStatus] Evaluation status of rule
-    def get_rule_evaluation_status(rule_name)
+    def get_rule_evaluation_status_by_name(rule_name)
       # https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html#describe_config_rule_evaluation_status-instance_method
       @cs.describe_config_rule_evaluation_status(
         config_rule_names: [rule_name]
@@ -61,7 +61,7 @@ module Cucloud
     # @param [String] Rule name
     # @return [Types::EvaluationResult]
     # @TODO verify that first return is always what we want?  i.e, always ordered decending by date?
-    def get_rule_compliance(rule_name)
+    def get_rule_compliance_by_name(rule_name)
       # https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html#describe_config_rule_evaluation_status-instance_method
       @cs.get_compliance_details_by_config_rule(
         config_rule_name: rule_name
@@ -69,35 +69,33 @@ module Cucloud
     end
 
     # Is this rule active?
-    # @param [String] Rule name
+    # @param [Aws::ConfigService::Types::ConfigRule] Rule
     # @return [Boolean]
-    def rule_active?(rule_name)
-      rule = get_config_rule_by_name(rule_name)
+    def rule_active?(rule)
       rule.config_rule_state == 'ACTIVE'
     end
 
     # Has this rule run in the last 24 hours?
-    # @param [String] Rule name
+    # @param [Aws::ConfigService::Types::ConfigRule] Rule
     # @return [Boolean]
-    def rule_ran_in_last_day?(rule_name)
-      last_run = get_rule_evaluation_status(rule_name).last_successful_invocation_time
+    def rule_ran_in_last_day?(rule)
+      last_run = get_rule_evaluation_status_by_name(rule.config_rule_name).last_successful_invocation_time
       yesterday = Time.now - (60 * 60 * 24)
       (yesterday <=> last_run) < 0
     end
 
     # Is this rule currently passing?
-    # @param [String] Rule name
+    # @param [Aws::ConfigService::Types::ConfigRule] Rule
     # @return [Boolean]
-    def rule_compliant?(rule_name)
-      get_rule_compliance(rule_name).compliance_type == 'COMPLIANT'
+    def rule_compliant?(rule)
+      get_rule_compliance_by_name(rule.config_rule_name).compliance_type == 'COMPLIANT'
     end
 
     # Is this a cloudtrail rule?
-    # @param [String] Rule name
+    # @param [Aws::ConfigService::Types::ConfigRule] Rule
     # @return [Boolean]
     # @TODO move this to cloudtrail util when it is created (?)
-    def rule_for_cloudtrail?(rule_name)
-      rule = get_config_rule_by_name(rule_name)
+    def rule_for_cloudtrail?(rule)
       rule.source.source_identifier == 'CLOUD_TRAIL_ENABLED' && rule.source.owner == 'AWS'
     end
   end

--- a/lib/cucloud/config_service_utils.rb
+++ b/lib/cucloud/config_service_utils.rb
@@ -1,0 +1,100 @@
+module Cucloud
+  # ConfigServiceUtils - Utilities for Config Service
+  class ConfigServiceUtils
+    # http://docs.aws.amazon.com/general/latest/gr/rande.html#awsconfig_region
+    CONFIG_REGIONS = ['us-east-1',
+                      'us-west-2',
+                      'eu-west-1',
+                      'eu-central-1',
+                      'ap-northeast-1'].freeze
+
+    # Declare error classes
+    class UnsupportedRegionError < StandardError
+    end
+
+    # Config service is limited to a subset of regions - get currently supported list
+    # @return [Array<String>] Array of region names
+    def self.get_available_regions
+      CONFIG_REGIONS
+    end
+
+    # Constructor for ConfigServiceUtilsclass
+    # @param asg_client [Aws::ConfigService::Client] AWS ConfigService SDK Client
+    def initialize(cs_client = Aws::ConfigService::Client.new)
+      ## DI for testing purposes
+      @cs = cs_client
+      @region = Cucloud.region
+    end
+
+    # Get array of configuration rules for given region
+    # @return [Array<Aws::ConfigService::Types::ConfigRule>] Array of config rules
+    def get_config_rules
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html#describe_config_rules-instance_method
+      @cs.describe_config_rules.config_rules
+    end
+
+    # Get specific config rule by name
+    # @param [String] Config rule name
+    # @return [Aws::ConfigService::Types::ConfigRule] Rule
+    def get_config_rule_by_name(rule_name)
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html#describe_config_rules-instance_method
+      @cs.describe_config_rules(
+        config_rule_names: [rule_name]
+      ).config_rules.first
+    end
+
+    # Get evaluation status of rule by name
+    # @param [String] Rule name
+    # @return [Types::ConfigRuleEvaluationStatus] Evaluation status of rule
+    def get_rule_evaluation_status(rule_name)
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html#describe_config_rule_evaluation_status-instance_method
+      @cs.describe_config_rule_evaluation_status(
+        config_rule_names: [rule_name]
+      ).config_rules_evaluation_status.first
+    end
+
+    # Get compliance details for a given rule by name
+    # @param [String] Rule name
+    # @return [Types::EvaluationResult]
+    # @TODO verify that first return is always what we want?  i.e, always ordered decending by date?
+    def get_rule_compliance(rule_name)
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/ConfigService/Client.html#describe_config_rule_evaluation_status-instance_method
+      @cs.get_compliance_details_by_config_rule(
+        config_rule_name: rule_name
+      ).evaluation_results.first
+    end
+
+    # Is this rule active?
+    # @param [String] Rule name
+    # @return [Boolean]
+    def rule_active?(rule_name)
+      rule = get_config_rule_by_name(rule_name)
+      rule.config_rule_state == 'ACTIVE'
+    end
+
+    # Has this rule run in the last 24 hours?
+    # @param [String] Rule name
+    # @return [Boolean]
+    def rule_ran_in_last_day?(rule_name)
+      last_run = get_rule_evaluation_status(rule_name).last_successful_invocation_time
+      yesterday = Time.now - (60 * 60 * 24)
+      (yesterday <=> last_run) < 0
+    end
+
+    # Is this rule currently passing?
+    # @param [String] Rule name
+    # @return [Boolean]
+    def rule_compliant?(rule_name)
+      get_rule_compliance(rule_name).compliance_type == 'COMPLIANT'
+    end
+
+    # Is this a cloudtrail rule?
+    # @param [String] Rule name
+    # @return [Boolean]
+    # @TODO move this to cloudtrail util when it is created (?)
+    def rule_for_cloudtrail?(rule_name)
+      rule = get_config_rule_by_name(rule_name)
+      rule.source.source_identifier == 'CLOUD_TRAIL_ENABLED' && rule.source.owner == 'AWS'
+    end
+  end
+end

--- a/spec/config_service_utils_spec.rb
+++ b/spec/config_service_utils_spec.rb
@@ -1,0 +1,351 @@
+require 'spec_helper'
+
+describe Cucloud::ConfigServiceUtils do
+  let(:cs_client) do
+    Aws::ConfigService::Client.new(stub_responses: true)
+  end
+
+  let(:cs_util) do
+    Cucloud::ConfigServiceUtils.new cs_client
+  end
+
+  it '.new default optional should be successful' do
+    expect(Cucloud::ConfigServiceUtils.new).to be_a_kind_of(Cucloud::ConfigServiceUtils)
+  end
+
+  it 'dependency injection asg_client should be successful' do
+    expect(Cucloud::ConfigServiceUtils.new(cs_client)).to be_a_kind_of(Cucloud::ConfigServiceUtils)
+  end
+
+  it 'get_available_regions class method call should be successful' do
+    expect(Cucloud::ConfigServiceUtils.get_available_regions.class.to_s).to eq 'Array'
+    expect(Cucloud::ConfigServiceUtils.get_available_regions.length).to eq 5
+  end
+
+  context 'while describe_config_rules is stubbed out with response' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'CLOUD_TRAIL_ENABLED',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          },
+          {
+            config_rule_name: 'test-rule-2',
+            config_rule_arn: 'test-rule-2-arn',
+            config_rule_id: 'test-rule-2-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-2 resource 2'],
+              tag_key: 'test-rule-2-tag-key',
+              tag_value: 'test-rule-2-tag-value',
+              compliance_resource_id: 'test-rule-2-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS',
+              source_identifier: 'SOMETHING_ELSE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-2-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+        ]
+
+      )
+    end
+
+    it "'get_config_rules' should return without an error" do
+      expect { cs_util.get_config_rules }.not_to raise_error
+    end
+
+    it "'get_config_rules' should return a 2 element array" do
+      expect(cs_util.get_config_rules.length).to eq 2
+    end
+
+    it "'get_config_rule_by_name' should return without an error" do
+      expect { cs_util.get_config_rule_by_name('test-rule-1') }.not_to raise_error
+    end
+
+    it "'get_config_rule_by_name' should return expected rule (first)" do
+      expect(cs_util.get_config_rule_by_name('test-rule-1').config_rule_arn).to eq 'test-rule-1-arn'
+    end
+  end
+
+  context 'while describe_config_rules is stubbed out active cloudtrail rule' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'CLOUD_TRAIL_ENABLED',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+        ]
+      )
+    end
+
+    it "'rule_active?' should return without an error" do
+      expect { cs_util.rule_active?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_active?' should return true" do
+      expect(cs_util.rule_active?('test-rule-1')).to eq true
+    end
+
+    it "'rule_for_cloudtrail?' should return without an error" do
+      expect { cs_util.rule_for_cloudtrail?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_for_cloudtrail?' should return true" do
+      expect(cs_util.rule_for_cloudtrail?('test-rule-1')).to eq true
+    end
+  end
+
+  context 'while describe_config_rules is stubbed out NON-active NON-cloudtrail rule' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'OTHER_RULE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'DELETING'
+          }
+        ]
+      )
+    end
+
+    it "'rule_active?' should return without an error" do
+      expect { cs_util.rule_active?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_active?' should return true" do
+      expect(cs_util.rule_active?('test-rule-1')).to eq false
+    end
+
+    it "'rule_for_cloudtrail?' should return without an error" do
+      expect { cs_util.rule_for_cloudtrail?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_for_cloudtrail?' should return false" do
+      expect(cs_util.rule_for_cloudtrail?('test-rule-1')).to eq false
+    end
+  end
+
+  context 'while describe_config_rule_evaluation_status is stubbed out as running in last day' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rule_evaluation_status,
+        config_rules_evaluation_status: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-arn-1',
+            config_rule_id: 'test-rule-id-1',
+            last_successful_invocation_time: Time.now - (60 * 60 * 23), # w/in last day
+            last_failed_invocation_time: Time.now - (60 * 60 * 23),
+            last_successful_evaluation_time: Time.now - (60 * 60 * 23),
+            last_failed_evaluation_time: Time.now - (60 * 60 * 23),
+            first_activated_time: Time.now - (60 * 60 * 23),
+            last_error_code: 'test-error-code',
+            last_error_message: 'test-error-message',
+            first_evaluation_started: true
+          }
+        ]
+      )
+    end
+
+    it "'get_rule_evaluation_status' should return without an error" do
+      expect { cs_util.get_rule_evaluation_status('test-rule-1') }.not_to raise_error
+    end
+
+    it "'get_rule_evaluation_status' should return rule w/ expected values" do
+      expect(cs_util.get_rule_evaluation_status('test-rule-1').config_rule_name).to eq 'test-rule-1'
+    end
+
+    it "'rule_ran_in_last_day?' should return without an error" do
+      expect { cs_util.rule_ran_in_last_day?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_ran_in_last_day?' should return true" do
+      expect(cs_util.rule_ran_in_last_day?('test-rule-1')).to eq true
+    end
+  end
+
+  context 'while describe_config_rule_evaluation_status is stubbed out as running > 24 hours ago' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rule_evaluation_status,
+        config_rules_evaluation_status: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-arn-1',
+            config_rule_id: 'test-rule-id-1',
+            last_successful_invocation_time: Time.now - (60 * 60 * 25),
+            last_failed_invocation_time: Time.now - (60 * 60 * 24),
+            last_successful_evaluation_time: Time.now - (60 * 60 * 24),
+            last_failed_evaluation_time: Time.now - (60 * 60 * 24),
+            first_activated_time: Time.now - (60 * 60 * 24),
+            last_error_code: 'test-error-code',
+            last_error_message: 'test-error-message',
+            first_evaluation_started: true
+          }
+        ]
+      )
+    end
+
+    it "'rule_ran_in_last_day?' should return without an error" do
+      expect { cs_util.rule_ran_in_last_day?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_ran_in_last_day?' should return false" do
+      expect(cs_util.rule_ran_in_last_day?('test-rule-1')).to eq false
+    end
+  end
+
+  context 'while get_compliance_details_by_config_rule is stubbed out with compliant response' do
+    before do
+      cs_client.stub_responses(
+        :get_compliance_details_by_config_rule,
+        evaluation_results: [
+          {
+            evaluation_result_identifier: {
+              evaluation_result_qualifier: {
+                config_rule_name: 'test-rule-1',
+                resource_type: 'test-resource-type',
+                resource_id: 'test-resource-id'
+              },
+              ordering_timestamp: Time.now - (60 * 60 * 24)
+            },
+            compliance_type: 'COMPLIANT',
+            result_recorded_time: Time.now - (60 * 60 * 24),
+            config_rule_invoked_time: Time.now - (60 * 60 * 24),
+            annotation: 'test-annotation',
+            result_token: 'test-token'
+          }
+        ]
+      )
+    end
+
+    it "'get_rule_compliance' should return without an error" do
+      expect { cs_util.get_rule_compliance('test-rule-1') }.not_to raise_error
+    end
+
+    it "'get_rule_compliance' should return rule w/ expected values" do
+      expect(cs_util.get_rule_compliance('test-rule-1').compliance_type).to eq 'COMPLIANT'
+    end
+
+    it "'rule_compliant?' should return without an error" do
+      expect { cs_util.rule_compliant?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_compliant?' should return true" do
+      expect(cs_util.rule_compliant?('test-rule-1')).to eq true
+    end
+  end
+
+  context 'while get_compliance_details_by_config_rule is stubbed out with NON-compliant response' do
+    before do
+      cs_client.stub_responses(
+        :get_compliance_details_by_config_rule,
+        evaluation_results: [
+          {
+            evaluation_result_identifier: {
+              evaluation_result_qualifier: {
+                config_rule_name: 'test-rule-1',
+                resource_type: 'test-resource-type',
+                resource_id: 'test-resource-id'
+              },
+              ordering_timestamp: Time.now - (60 * 60 * 24)
+            },
+            compliance_type: 'NON-COMPLIANT',
+            result_recorded_time: Time.now - (60 * 60 * 24),
+            config_rule_invoked_time: Time.now - (60 * 60 * 24),
+            annotation: 'test-annotation',
+            result_token: 'test-token'
+          }
+        ]
+      )
+    end
+
+    it "'rule_compliant?' should return without an error" do
+      expect { cs_util.rule_compliant?('test-rule-1') }.not_to raise_error
+    end
+
+    it "'rule_compliant?' should return false" do
+      expect(cs_util.rule_compliant?('test-rule-1')).to eq false
+    end
+  end
+end

--- a/spec/config_service_utils_spec.rb
+++ b/spec/config_service_utils_spec.rb
@@ -17,6 +17,12 @@ describe Cucloud::ConfigServiceUtils do
     expect(Cucloud::ConfigServiceUtils.new(cs_client)).to be_a_kind_of(Cucloud::ConfigServiceUtils)
   end
 
+  it '.new should throw Cucloud::ConfigServiceUtils::UnsupportedRegionError when using unsupported region' do
+    Cucloud.region = 'us-west-1'
+    expect { Cucloud::ConfigServiceUtils.new }.to raise_error(Cucloud::ConfigServiceUtils::UnsupportedRegionError)
+    Cucloud.region = Cucloud::DEFAULT_REGION # set it back to default so the rest of our tests pass!
+  end
+
   it 'get_available_regions class method call should be successful' do
     expect(Cucloud::ConfigServiceUtils.get_available_regions.class.to_s).to eq 'Array'
     expect(Cucloud::ConfigServiceUtils.get_available_regions.length).to eq 5
@@ -192,7 +198,7 @@ describe Cucloud::ConfigServiceUtils do
       expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
-    it "'rule_active?' should return true" do
+    it "'rule_active?' should return false" do
       expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
     end
 

--- a/spec/config_service_utils_spec.rb
+++ b/spec/config_service_utils_spec.rb
@@ -137,19 +137,19 @@ describe Cucloud::ConfigServiceUtils do
     end
 
     it "'rule_active?' should return without an error" do
-      expect { cs_util.rule_active?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_active?' should return true" do
-      expect(cs_util.rule_active?('test-rule-1')).to eq true
+      expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
     end
 
     it "'rule_for_cloudtrail?' should return without an error" do
-      expect { cs_util.rule_for_cloudtrail?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_for_cloudtrail?' should return true" do
-      expect(cs_util.rule_for_cloudtrail?('test-rule-1')).to eq true
+      expect(cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
     end
   end
 
@@ -189,24 +189,56 @@ describe Cucloud::ConfigServiceUtils do
     end
 
     it "'rule_active?' should return without an error" do
-      expect { cs_util.rule_active?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_active?' should return true" do
-      expect(cs_util.rule_active?('test-rule-1')).to eq false
+      expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
     end
 
     it "'rule_for_cloudtrail?' should return without an error" do
-      expect { cs_util.rule_for_cloudtrail?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_for_cloudtrail?' should return false" do
-      expect(cs_util.rule_for_cloudtrail?('test-rule-1')).to eq false
+      expect(cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
     end
   end
 
   context 'while describe_config_rule_evaluation_status is stubbed out as running in last day' do
     before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'OTHER_RULE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+        ]
+      )
+
       cs_client.stub_responses(
         :describe_config_rule_evaluation_status,
         config_rules_evaluation_status: [
@@ -227,25 +259,57 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'get_rule_evaluation_status' should return without an error" do
-      expect { cs_util.get_rule_evaluation_status('test-rule-1') }.not_to raise_error
+    it "'get_rule_evaluation_status_by_name' should return without an error" do
+      expect { cs_util.get_rule_evaluation_status_by_name('test-rule-1') }.not_to raise_error
     end
 
-    it "'get_rule_evaluation_status' should return rule w/ expected values" do
-      expect(cs_util.get_rule_evaluation_status('test-rule-1').config_rule_name).to eq 'test-rule-1'
+    it "'get_rule_evaluation_status_by_name' should return rule w/ expected values" do
+      expect(cs_util.get_rule_evaluation_status_by_name('test-rule-1').config_rule_name).to eq 'test-rule-1'
     end
 
     it "'rule_ran_in_last_day?' should return without an error" do
-      expect { cs_util.rule_ran_in_last_day?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_ran_in_last_day?' should return true" do
-      expect(cs_util.rule_ran_in_last_day?('test-rule-1')).to eq true
+      expect(cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
     end
   end
 
   context 'while describe_config_rule_evaluation_status is stubbed out as running > 24 hours ago' do
     before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'OTHER_RULE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+        ]
+      )
+
       cs_client.stub_responses(
         :describe_config_rule_evaluation_status,
         config_rules_evaluation_status: [
@@ -267,16 +331,48 @@ describe Cucloud::ConfigServiceUtils do
     end
 
     it "'rule_ran_in_last_day?' should return without an error" do
-      expect { cs_util.rule_ran_in_last_day?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_ran_in_last_day?' should return false" do
-      expect(cs_util.rule_ran_in_last_day?('test-rule-1')).to eq false
+      expect(cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
     end
   end
 
   context 'while get_compliance_details_by_config_rule is stubbed out with compliant response' do
     before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'OTHER_RULE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+        ]
+      )
+
       cs_client.stub_responses(
         :get_compliance_details_by_config_rule,
         evaluation_results: [
@@ -299,25 +395,57 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'get_rule_compliance' should return without an error" do
-      expect { cs_util.get_rule_compliance('test-rule-1') }.not_to raise_error
+    it "'get_rule_compliance_by_name' should return without an error" do
+      expect { cs_util.get_rule_compliance_by_name('test-rule-1') }.not_to raise_error
     end
 
-    it "'get_rule_compliance' should return rule w/ expected values" do
-      expect(cs_util.get_rule_compliance('test-rule-1').compliance_type).to eq 'COMPLIANT'
+    it "'get_rule_compliance_by_name' should return rule w/ expected values" do
+      expect(cs_util.get_rule_compliance_by_name('test-rule-1').compliance_type).to eq 'COMPLIANT'
     end
 
     it "'rule_compliant?' should return without an error" do
-      expect { cs_util.rule_compliant?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_compliant?' should return true" do
-      expect(cs_util.rule_compliant?('test-rule-1')).to eq true
+      expect(cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
     end
   end
 
   context 'while get_compliance_details_by_config_rule is stubbed out with NON-compliant response' do
     before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'OTHER_RULE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+        ]
+      )
+
       cs_client.stub_responses(
         :get_compliance_details_by_config_rule,
         evaluation_results: [
@@ -341,11 +469,11 @@ describe Cucloud::ConfigServiceUtils do
     end
 
     it "'rule_compliant?' should return without an error" do
-      expect { cs_util.rule_compliant?('test-rule-1') }.not_to raise_error
+      expect { cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
     it "'rule_compliant?' should return false" do
-      expect(cs_util.rule_compliant?('test-rule-1')).to eq false
+      expect(cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
     end
   end
 end


### PR DESCRIPTION
Adds support to do ruleset lookups from config service + provides some helper functions to evaluate rules (e.g., is it active?  is it in compliance?).  Will be injected into forthcoming cloudtrail utility library for use in checking specific cloudtrail config rules.
