### PR TITLE
Add cloudtrail utility library

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ To install this gem onto your local machine:
 
 It's helpful to reference a local copy of the gem while developing (so you can add methods to cucloud and reference them in the utility you are developing) -- see https://rossta.net/blog/how-to-specify-local-ruby-gems-in-your-gemfile.html for a recommended approach.
 
+Development documentation is generated automatically from yard and is available at: http://www.rubydoc.info/gems/cucloud
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/CU-CloudCollab/cucloud_ruby. The library includes functions that have been needed somewhere already - it is in no way complete yet and we love contributions!
@@ -80,4 +82,3 @@ General guidance for contributions:
 * Code should conform to Ruby Community Styleguide and pass rubocop checks using the included rubocop config (https://github.com/bbatsov/ruby-style-guide).
 
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-

--- a/lib/cucloud.rb
+++ b/lib/cucloud.rb
@@ -9,6 +9,7 @@ module Cucloud
   require 'cucloud/iam_utils'
   require 'cucloud/vpc_utils'
   require 'cucloud/config_service_utils'
+  require 'cucloud/cloud_trail_utils'
 
   # This is the default region API calls are made against
   DEFAULT_REGION = 'us-east-1'.freeze

--- a/lib/cucloud/cloud_trail_utils.rb
+++ b/lib/cucloud/cloud_trail_utils.rb
@@ -1,0 +1,70 @@
+module Cucloud
+  # CloudTrailUtils - Utilities for Cloud Trail
+  class CloudTrailUtils
+    # Regex used to determine if a cloudtrail rule belongs to ITSO
+    ITSO_CLOUDTRAIL_ARN_REGEX = %r{arn:aws:cloudtrail:us-east-1:.*:trail\/.*[Ii][Tt][Ss][Oo].*}
+
+    # Constructor for CloudTrailUtils class
+    # @param ct_client [Aws::CloudTrail::Client] AWS CloudTrail SDK Client
+    def initialize(ct_client = Aws::CloudTrail::Client.new, cs_utils = Cucloud::ConfigServiceUtils.new)
+      ## DI for testing purposes
+      @ct = ct_client
+      @cs_utils = cs_utils
+      @region = Cucloud.region
+    end
+
+    # Get all cloud trails for this region
+    # @return [Array<Aws::CloudTrail::Types::Trail>]
+    def get_cloud_trails
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudTrail/Client.html#describe_trails-instance_method
+      @ct.describe_trails(include_shadow_trails: false).trail_list
+    end
+
+    # Get all cloud trails for this region
+    # @return [Aws::CloudTrail::Types::Trail]
+    def get_cloud_trail_by_name(trail_name)
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudTrail/Client.html#describe_trails-instance_method
+      @ct.describe_trails(trail_name_list: [trail_name], include_shadow_trails: false).trail_list.first
+    end
+
+    # Is this trail a global trail
+    # @param [Aws::CloudTrail::Types::Trail]
+    # @return [Aws::CloudTrail::Types::GetTrailStatusResponse]
+    def get_trail_status(trail)
+      # https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudTrail/Client.html#get_trail_status-instance_method
+      @ct.get_trail_status(name: trail.name)
+    end
+
+    # Is this trail a global trail
+    # @param [Aws::CloudTrail::Types::Trail]
+    # @return [Boolean]
+    def global_trail?(trail)
+      trail.include_global_service_events && trail.is_multi_region_trail
+    end
+
+    # Is Cornell ITSO Trail?
+    # @param [Aws::CloudTrail::Types::Trail]
+    # @return [Boolean]
+    def cornell_itso_trail?(trail)
+      !(trail.trail_arn =~ ITSO_CLOUDTRAIL_ARN_REGEX).nil?
+    end
+
+    # Is this trail logging?
+    # @param [Aws::CloudTrail::Types::Trail]
+    # @return [Boolean]
+    def trail_logging_active?(trail)
+      status = get_trail_status(trail)
+      status.is_logging && !status.latest_delivery_time.nil?
+    end
+
+    # Get hours since last delivery
+    # @param [Aws::CloudTrail::Types::Trail]
+    # @return [Integer] Hours
+    def hours_since_last_delivery(trail)
+      status = get_trail_status(trail)
+      return nil if status.latest_delivery_time.nil?
+
+      ((Time.now - status.latest_delivery_time) / 60 / 60).to_i
+    end
+  end
+end

--- a/lib/cucloud/cloud_trail_utils.rb
+++ b/lib/cucloud/cloud_trail_utils.rb
@@ -20,6 +20,14 @@ module Cucloud
       @ct.describe_trails(include_shadow_trails: false).trail_list
     end
 
+    # Get all cloud trail config rules for this region
+    # @return [Array<Aws::ConfigService::Types::ConfigRule>]
+    def get_config_rules
+      @cs_utils.get_config_rules.select do |rule|
+        rule.source.source_identifier == 'CLOUD_TRAIL_ENABLED' && rule.source.owner == 'AWS'
+      end
+    end
+
     # Get all cloud trails for this region
     # @return [Aws::CloudTrail::Types::Trail]
     def get_cloud_trail_by_name(trail_name)

--- a/lib/cucloud/config_service_utils.rb
+++ b/lib/cucloud/config_service_utils.rb
@@ -90,13 +90,5 @@ module Cucloud
     def rule_compliant?(rule)
       get_rule_compliance_by_name(rule.config_rule_name).compliance_type == 'COMPLIANT'
     end
-
-    # Is this a cloudtrail rule?
-    # @param [Aws::ConfigService::Types::ConfigRule] Rule
-    # @return [Boolean]
-    # @TODO move this to cloudtrail util when it is created (?)
-    def rule_for_cloudtrail?(rule)
-      rule.source.source_identifier == 'CLOUD_TRAIL_ENABLED' && rule.source.owner == 'AWS'
-    end
   end
 end

--- a/lib/cucloud/config_service_utils.rb
+++ b/lib/cucloud/config_service_utils.rb
@@ -75,20 +75,21 @@ module Cucloud
       rule.config_rule_state == 'ACTIVE'
     end
 
-    # Has this rule run in the last 24 hours?
-    # @param [Aws::ConfigService::Types::ConfigRule] Rule
-    # @return [Boolean]
-    def rule_ran_in_last_day?(rule)
-      last_run = get_rule_evaluation_status_by_name(rule.config_rule_name).last_successful_invocation_time
-      yesterday = Time.now - (60 * 60 * 24)
-      (yesterday <=> last_run) < 0
-    end
-
     # Is this rule currently passing?
     # @param [Aws::ConfigService::Types::ConfigRule] Rule
     # @return [Boolean]
     def rule_compliant?(rule)
       get_rule_compliance_by_name(rule.config_rule_name).compliance_type == 'COMPLIANT'
+    end
+
+    # Get hours since last config check invocation
+    # @param [Aws::ConfigService::Types::ConfigRule] Rule
+    # @return [Integer] Hours
+    def hours_since_last_run(rule)
+      last_run_time = get_rule_evaluation_status_by_name(rule.config_rule_name).last_successful_invocation_time
+      return nil if last_run_time.nil?
+
+      ((Time.now - last_run_time) / 60 / 60).to_i
     end
   end
 end

--- a/spec/asg_utils_spec.rb
+++ b/spec/asg_utils_spec.rb
@@ -182,7 +182,8 @@ describe Cucloud::AsgUtils do
           asg_util.generate_lc_options_hash_with_ami(
             asg_util.get_launch_configuration_by_name('test-lc'),
             'new-ami'
-          )[:launch_configuration_name] == asg_util.get_launch_configuration_by_name('test-lc').launch_configuration_name
+          )[:launch_configuration_name] == asg_util.get_launch_configuration_by_name('test-lc')
+                                                   .launch_configuration_name
         ).to eq false
       end
 

--- a/spec/asg_utils_spec.rb
+++ b/spec/asg_utils_spec.rb
@@ -37,16 +37,18 @@ describe Cucloud::AsgUtils do
       )
     end
 
-    it "'get_asg_by_name' should return without an error" do
-      expect { asg_util.get_asg_by_name('test-group') }.not_to raise_error
-    end
+    describe '#get_asg_by_name' do
+      it 'should return without an error' do
+        expect { asg_util.get_asg_by_name('test-group') }.not_to raise_error
+      end
 
-    it "'get_asg_by_name' should return first result" do
-      expect(asg_util.get_asg_by_name('test-group').auto_scaling_group_name.to_s).to eq 'test-group'
-    end
+      it 'should return first result' do
+        expect(asg_util.get_asg_by_name('test-group').auto_scaling_group_name.to_s).to eq 'test-group'
+      end
 
-    it "'get_asg_by_name' should return type Aws::AutoScaling::Types::AutoScalingGroup" do
-      expect(asg_util.get_asg_by_name('test-group').class.to_s).to eq 'Aws::AutoScaling::Types::AutoScalingGroup'
+      it 'should return type Aws::AutoScaling::Types::AutoScalingGroup' do
+        expect(asg_util.get_asg_by_name('test-group').class.to_s).to eq 'Aws::AutoScaling::Types::AutoScalingGroup'
+      end
     end
   end
 
@@ -59,12 +61,14 @@ describe Cucloud::AsgUtils do
       )
     end
 
-    it "'get_asg_by_name' should return without an error" do
-      expect { asg_util.get_asg_by_name('test-group') }.not_to raise_error
-    end
+    describe '#get_asg_by_name' do
+      it 'should return without an error' do
+        expect { asg_util.get_asg_by_name('test-group') }.not_to raise_error
+      end
 
-    it "'get_asg_by_name' should return nil" do
-      expect(asg_util.get_asg_by_name('test-group').nil?).to eq true
+      it 'should return nil' do
+        expect(asg_util.get_asg_by_name('test-group').nil?).to eq true
+      end
     end
   end
 
@@ -121,116 +125,124 @@ describe Cucloud::AsgUtils do
       )
     end
 
-    it "'get_launch_configuration_by_name' should return without an error" do
-      expect { asg_util.get_launch_configuration_by_name('test-lc') }.not_to raise_error
+    describe '#get_launch_configuration_by_name' do
+      it 'should return without an error' do
+        expect { asg_util.get_launch_configuration_by_name('test-lc') }.not_to raise_error
+      end
+
+      it 'should return first result' do
+        expect(asg_util.get_launch_configuration_by_name('test-lc').launch_configuration_name.to_s).to eq 'test-lc'
+      end
+
+      it 'should return type Aws::AutoScaling::Types::LaunchConfiguration' do
+        expect(asg_util.get_launch_configuration_by_name('test-lc').class.to_s)
+          .to eq 'Aws::AutoScaling::Types::LaunchConfiguration'
+      end
     end
 
-    it "'get_launch_configuration_by_name' should return first result" do
-      expect(asg_util.get_launch_configuration_by_name('test-lc').launch_configuration_name.to_s).to eq 'test-lc'
-    end
+    describe '#generate_lc_options_hash_with_ami' do
+      it 'should return without an error' do
+        expect do
+          asg_util.generate_lc_options_hash_with_ami(
+            asg_util.get_launch_configuration_by_name('test-lc'),
+            'new-ami'
+          )
+        end.not_to raise_error
+      end
 
-    it "'get_launch_configuration_by_name' should return type Aws::AutoScaling::Types::LaunchConfiguration" do
-      expect(asg_util.get_launch_configuration_by_name('test-lc').class.to_s)
-        .to eq 'Aws::AutoScaling::Types::LaunchConfiguration'
-    end
+      it 'should return hash with new ami' do
+        expect(
+          asg_util.generate_lc_options_hash_with_ami(
+            asg_util.get_launch_configuration_by_name('test-lc'),
+            'new-ami'
+          )[:image_id]
+        ).to eq 'new-ami'
+      end
 
-    it "'generate_lc_options_hash_with_ami' should return without an error" do
-      expect do
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami'
-        )
-      end.not_to raise_error
-    end
+      it 'should not include a launch config arn' do
+        expect(
+          asg_util.generate_lc_options_hash_with_ami(
+            asg_util.get_launch_configuration_by_name('test-lc'),
+            'new-ami'
+          )[:launch_configuration_arn].nil?
+        ).to eq true
+      end
 
-    it "'generate_lc_options_hash_with_ami' should return hash with new ami" do
-      expect(
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami'
-        )[:image_id]
-      ).to eq 'new-ami'
-    end
+      it 'should not include a created_time' do
+        expect(
+          asg_util.generate_lc_options_hash_with_ami(
+            asg_util.get_launch_configuration_by_name('test-lc'),
+            'new-ami'
+          )[:created_time].nil?
+        ).to eq true
+      end
 
-    it "'generate_lc_options_hash_with_ami' should not include a launch config arn" do
-      expect(
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami'
-        )[:launch_configuration_arn].nil?
-      ).to eq true
-    end
+      it 'with default param, should generate a new launch configuration name' do
+        expect(
+          asg_util.generate_lc_options_hash_with_ami(
+            asg_util.get_launch_configuration_by_name('test-lc'),
+            'new-ami'
+          )[:launch_configuration_name] == asg_util.get_launch_configuration_by_name('test-lc').launch_configuration_name
+        ).to eq false
+      end
 
-    it "'generate_lc_options_hash_with_ami' should not include a created_time" do
-      expect(
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami'
-        )[:created_time].nil?
-      ).to eq true
-    end
-
-    it "'generate_lc_options_hash_with_ami', with default param, should generate a new launch configuration name" do
-      expect(
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami'
-        )[:launch_configuration_name] == asg_util.get_launch_configuration_by_name('test-lc').launch_configuration_name
-      ).to eq false
-    end
-
-    it "'generate_lc_options_hash_with_ami', should use requested config name when specified" do
-      expect(
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami',
-          'new-specified-config-name'
-        )[:launch_configuration_name] == 'new-specified-config-name'
-      ).to eq true
-    end
-
-    it "'generate_lc_options_hash_with_ami', should not include any empty string values" do
-      expect(
-        asg_util.generate_lc_options_hash_with_ami(
-          asg_util.get_launch_configuration_by_name('test-lc'),
-          'new-ami',
-          'new-specified-config-name'
-        ).select { |_k, v| v == '' }.empty?
-      ).to eq true
-    end
-
-    it "'create_launch_configuration', should return without an error" do
-      expect do
-        asg_util.create_launch_configuration(
+      it 'should use requested config name when specified' do
+        expect(
           asg_util.generate_lc_options_hash_with_ami(
             asg_util.get_launch_configuration_by_name('test-lc'),
             'new-ami',
             'new-specified-config-name'
-          )
-        )
-      end.not_to raise_error
-    end
+          )[:launch_configuration_name] == 'new-specified-config-name'
+        ).to eq true
+      end
 
-    it "'create_launch_configuration' should return type Seahorse::Client::Response" do
-      expect(
-        asg_util.create_launch_configuration(
+      it 'should not include any empty string values' do
+        expect(
           asg_util.generate_lc_options_hash_with_ami(
             asg_util.get_launch_configuration_by_name('test-lc'),
             'new-ami',
             'new-specified-config-name'
+          ).select { |_k, v| v == '' }.empty?
+        ).to eq true
+      end
+    end
+
+    describe '#create_launch_configuration' do
+      it 'should return without an error' do
+        expect do
+          asg_util.create_launch_configuration(
+            asg_util.generate_lc_options_hash_with_ami(
+              asg_util.get_launch_configuration_by_name('test-lc'),
+              'new-ami',
+              'new-specified-config-name'
+            )
           )
-        ).class.to_s
-      ).to eq 'Seahorse::Client::Response'
+        end.not_to raise_error
+      end
+
+      it 'should return type Seahorse::Client::Response' do
+        expect(
+          asg_util.create_launch_configuration(
+            asg_util.generate_lc_options_hash_with_ami(
+              asg_util.get_launch_configuration_by_name('test-lc'),
+              'new-ami',
+              'new-specified-config-name'
+            )
+          ).class.to_s
+        ).to eq 'Seahorse::Client::Response'
+      end
     end
 
-    it "'update_asg_launch_configuration!', should return without an error" do
-      expect { asg_util.update_asg_launch_configuration!('asg-name', 'launch-config-name') }.not_to raise_error
-    end
+    describe '#update_asg_launch_configuration!' do
+      it 'should return without an error' do
+        expect { asg_util.update_asg_launch_configuration!('asg-name', 'launch-config-name') }.not_to raise_error
+      end
 
-    it "'update_asg_launch_configuration!' should return type Seahorse::Client::Response" do
-      expect(
-        asg_util.update_asg_launch_configuration!('asg-name', 'launch-config-name').class.to_s
-      ).to eq 'Seahorse::Client::Response'
+      it 'should return type Seahorse::Client::Response' do
+        expect(
+          asg_util.update_asg_launch_configuration!('asg-name', 'launch-config-name').class.to_s
+        ).to eq 'Seahorse::Client::Response'
+      end
     end
   end
 
@@ -243,12 +255,14 @@ describe Cucloud::AsgUtils do
       )
     end
 
-    it "'get_launch_configuration_by_name' should return without an error" do
-      expect { asg_util.get_launch_configuration_by_name('test-lc') }.not_to raise_error
-    end
+    describe '#get_launch_configuration_by_name' do
+      it 'should return without an error' do
+        expect { asg_util.get_launch_configuration_by_name('test-lc') }.not_to raise_error
+      end
 
-    it "'get_launch_configuration_by_name' should return nil" do
-      expect(asg_util.get_launch_configuration_by_name('test-lc').nil?).to eq true
+      it 'should return nil' do
+        expect(asg_util.get_launch_configuration_by_name('test-lc').nil?).to eq true
+      end
     end
   end
 end

--- a/spec/cloud_trail_utils_spec.rb
+++ b/spec/cloud_trail_utils_spec.rb
@@ -49,36 +49,44 @@ describe Cucloud::CloudTrailUtils do
       )
     end
 
-    it "'get_cloud_trails' should return without an error" do
-      expect { ct_util.get_cloud_trails }.not_to raise_error
+    describe '#get_cloud_trails' do
+      it 'should return without an error' do
+        expect { ct_util.get_cloud_trails }.not_to raise_error
+      end
+
+      it 'should return a 1 element array' do
+        expect(ct_util.get_cloud_trails.length).to eq 1
+      end
     end
 
-    it "'get_cloud_trails' should return a 1 element array" do
-      expect(ct_util.get_cloud_trails.length).to eq 1
+    describe '#get_cloud_trail_by_name' do
+      it 'should return without an error' do
+        expect { ct_util.get_cloud_trail_by_name('test-trail-1') }.not_to raise_error
+      end
+
+      it 'should return expected trail (first)' do
+        expect(ct_util.get_cloud_trail_by_name('test-trail-1').name).to eq 'test-trail-1'
+      end
     end
 
-    it "'get_cloud_trail_by_name' should return without an error" do
-      expect { ct_util.get_cloud_trail_by_name('test-trail-1') }.not_to raise_error
+    describe '#global_trail?' do
+      it 'should return without an error' do
+        expect { ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
+
+      it 'should return true' do
+        expect(ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+      end
     end
 
-    it "'get_cloud_trail_by_name' should return expected trail (first)" do
-      expect(ct_util.get_cloud_trail_by_name('test-trail-1').name).to eq 'test-trail-1'
-    end
+    describe '#cornell_itso_trail?' do
+      it 'should return without an error' do
+        expect { ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
 
-    it "'global_trail?' should return without an error" do
-      expect { ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
-    end
-
-    it "'global_trail?' should return true" do
-      expect(ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
-    end
-
-    it "'cornell_itso_trail?' should return without an error" do
-      expect { ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
-    end
-
-    it "'cornell_itso_trail?' should return true" do
-      expect(ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+      it 'should return true' do
+        expect(ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+      end
     end
   end
 
@@ -106,20 +114,24 @@ describe Cucloud::CloudTrailUtils do
       )
     end
 
-    it "'global_trail?' should return without an error" do
-      expect { ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    describe '#global_trail?' do
+      it 'should return without an error' do
+        expect { ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
+
+      it 'should return false' do
+        expect(ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+      end
     end
 
-    it "'global_trail?' should return false" do
-      expect(ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
-    end
+    describe '#cornell_itso_trail?' do
+      it 'should return without an error' do
+        expect { ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
 
-    it "'cornell_itso_trail?' should return without an error" do
-      expect { ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
-    end
-
-    it "'cornell_itso_trail?' should return false" do
-      expect(ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+      it 'should return false' do
+        expect(ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+      end
     end
   end
 
@@ -168,29 +180,35 @@ describe Cucloud::CloudTrailUtils do
       )
     end
 
-    it "'get_trail_status' should return without an error" do
-      expect { ct_util.get_trail_status(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    describe '#get_trail_status' do
+      it 'should return without an error' do
+        expect { ct_util.get_trail_status(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
+
+      it 'should return expected value' do
+        expect(ct_util.get_trail_status(ct_util.get_cloud_trail_by_name('test-trail-1'))
+               .latest_delivery_error).to eq 'test-error-1'
+      end
     end
 
-    it "'get_trail_status' should return expected value" do
-      expect(ct_util.get_trail_status(ct_util.get_cloud_trail_by_name('test-trail-1'))
-             .latest_delivery_error).to eq 'test-error-1'
+    describe '#trail_logging_active?' do
+      it 'should return without an error' do
+        expect { ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
+
+      it 'should return true' do
+        expect(ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+      end
     end
 
-    it "'trail_logging_active?' should return without an error" do
-      expect { ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
-    end
+    describe '#hours_since_last_delivery' do
+      it 'should return without an error' do
+        expect { ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
 
-    it "'trail_logging_active?' should return true" do
-      expect(ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
-    end
-
-    it "'hours_since_last_delivery' should return without an error" do
-      expect { ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
-    end
-
-    it "'hours_since_last_delivery' should return 23" do
-      expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq 23
+      it 'should return 23' do
+        expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq 23
+      end
     end
   end
 
@@ -239,20 +257,24 @@ describe Cucloud::CloudTrailUtils do
       )
     end
 
-    it "'trail_logging_active?' should return without an error" do
-      expect { ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    describe '#trail_logging_active?' do
+      it 'should return without an error' do
+        expect { ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
+
+      it 'should return false' do
+        expect(ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+      end
     end
 
-    it "'trail_logging_active?' should return false" do
-      expect(ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
-    end
+    describe '#hours_since_last_delivery' do
+      it 'should return without an error' do
+        expect { ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+      end
 
-    it "'hours_since_last_delivery' should return without an error" do
-      expect { ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
-    end
-
-    it "'hours_since_last_delivery' should return nil" do
-      expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')).nil?).to eq true
+      it 'should return nil' do
+        expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')).nil?).to eq true
+      end
     end
   end
 
@@ -318,16 +340,18 @@ describe Cucloud::CloudTrailUtils do
       )
     end
 
-    it "'get_config_rules' should return without an error" do
-      expect { ct_util.get_config_rules }.not_to raise_error
-    end
+    describe '#get_config_rules' do
+      it 'should return without an error' do
+        expect { ct_util.get_config_rules }.not_to raise_error
+      end
 
-    it "'get_config_rules' should return array len 1" do
-      expect(ct_util.get_config_rules.length).to eq 1
-    end
+      it 'should return array len 1' do
+        expect(ct_util.get_config_rules.length).to eq 1
+      end
 
-    it "'get_config_rules' should return expected values" do
-      expect(ct_util.get_config_rules.first.config_rule_name).to eq 'test-rule-1'
+      it 'should return expected values' do
+        expect(ct_util.get_config_rules.first.config_rule_name).to eq 'test-rule-1'
+      end
     end
   end
 
@@ -339,12 +363,14 @@ describe Cucloud::CloudTrailUtils do
       )
     end
 
-    it "'get_config_rules' should return without an error" do
-      expect { ct_util.get_config_rules }.not_to raise_error
-    end
+    describe '#get_config_rules' do
+      it 'should return without an error' do
+        expect { ct_util.get_config_rules }.not_to raise_error
+      end
 
-    it "'get_config_rules' should return array len 0" do
-      expect(ct_util.get_config_rules.length).to eq 0
+      it 'should return array len 0' do
+        expect(ct_util.get_config_rules.length).to eq 0
+      end
     end
   end
 end

--- a/spec/cloud_trail_utils_spec.rb
+++ b/spec/cloud_trail_utils_spec.rb
@@ -1,0 +1,258 @@
+require 'spec_helper'
+
+describe Cucloud::CloudTrailUtils do
+  let(:ct_client) do
+    Aws::CloudTrail::Client.new(stub_responses: true)
+  end
+
+  let(:cs_client) do
+    Aws::ConfigService::Client.new(stub_responses: true)
+  end
+
+  let(:cs_util) do
+    Cucloud::ConfigServiceUtils.new cs_client
+  end
+
+  let(:ct_util) do
+    Cucloud::CloudTrailUtils.new ct_client, cs_util
+  end
+
+  it '.new default optional should be successful' do
+    expect(Cucloud::CloudTrailUtils.new).to be_a_kind_of(Cucloud::CloudTrailUtils)
+  end
+
+  it 'dependency injection ct_client should be successful' do
+    expect(Cucloud::CloudTrailUtils.new(ct_client)).to be_a_kind_of(Cucloud::CloudTrailUtils)
+  end
+
+  context 'while describe_trails is stubbed out with global ITSO trail' do
+    before do
+      ct_client.stub_responses(
+        :describe_trails,
+        trail_list: [
+          {
+            name: 'test-trail-1',
+            s3_bucket_name: 'test-trail-bucket-1',
+            s3_key_prefix: 'test-trail-prefix-1',
+            sns_topic_name: 'test-trail-sns-name-1',
+            sns_topic_arn: 'test-trail-sns-arn-1',
+            include_global_service_events: true,
+            is_multi_region_trail: true,
+            home_region: 'test-trail-region-1',
+            trail_arn: 'arn:aws:cloudtrail:us-east-1:444444444444444:trail/itso',
+            log_file_validation_enabled: true,
+            cloud_watch_logs_log_group_arn: 'test-trail-cw-group-arn-1',
+            cloud_watch_logs_role_arn: 'test-trail-cw-role-arn-1',
+            kms_key_id: 'test-trail-kms-key-1'
+          }
+        ]
+      )
+    end
+
+    it "'get_cloud_trails' should return without an error" do
+      expect { ct_util.get_cloud_trails }.not_to raise_error
+    end
+
+    it "'get_cloud_trails' should return a 1 element array" do
+      expect(ct_util.get_cloud_trails.length).to eq 1
+    end
+
+    it "'get_cloud_trail_by_name' should return without an error" do
+      expect { ct_util.get_cloud_trail_by_name('test-trail-1') }.not_to raise_error
+    end
+
+    it "'get_cloud_trail_by_name' should return expected trail (first)" do
+      expect(ct_util.get_cloud_trail_by_name('test-trail-1').name).to eq 'test-trail-1'
+    end
+
+    it "'global_trail?' should return without an error" do
+      expect { ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'global_trail?' should return true" do
+      expect(ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+    end
+
+    it "'cornell_itso_trail?' should return without an error" do
+      expect { ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'cornell_itso_trail?' should return true" do
+      expect(ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+    end
+  end
+
+  context 'while describe_trails is stubbed out with non-global non-ITSO trail' do
+    before do
+      ct_client.stub_responses(
+        :describe_trails,
+        trail_list: [
+          {
+            name: 'test-trail-1',
+            s3_bucket_name: 'test-trail-bucket-1',
+            s3_key_prefix: 'test-trail-prefix-1',
+            sns_topic_name: 'test-trail-sns-name-1',
+            sns_topic_arn: 'test-trail-sns-arn-1',
+            include_global_service_events: false,
+            is_multi_region_trail: true,
+            home_region: 'test-trail-region-1',
+            trail_arn: 'arn:aws:cloudtrail:us-east-1:444444444444444:trail/fjdkd',
+            log_file_validation_enabled: true,
+            cloud_watch_logs_log_group_arn: 'test-trail-cw-group-arn-1',
+            cloud_watch_logs_role_arn: 'test-trail-cw-role-arn-1',
+            kms_key_id: 'test-trail-kms-key-1'
+          }
+        ]
+      )
+    end
+
+    it "'global_trail?' should return without an error" do
+      expect { ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'global_trail?' should return false" do
+      expect(ct_util.global_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+    end
+
+    it "'cornell_itso_trail?' should return without an error" do
+      expect { ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'cornell_itso_trail?' should return false" do
+      expect(ct_util.cornell_itso_trail?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+    end
+  end
+
+  context 'while get_trail_status is stubbed out with active logging response' do
+    before do
+      ct_client.stub_responses(
+        :describe_trails,
+        trail_list: [
+          {
+            name: 'test-trail-1',
+            s3_bucket_name: 'test-trail-bucket-1',
+            s3_key_prefix: 'test-trail-prefix-1',
+            sns_topic_name: 'test-trail-sns-name-1',
+            sns_topic_arn: 'test-trail-sns-arn-1',
+            include_global_service_events: true,
+            is_multi_region_trail: true,
+            home_region: 'test-trail-region-1',
+            trail_arn: 'arn:aws:cloudtrail:us-east-1:444444444444444:trail/itso',
+            log_file_validation_enabled: true,
+            cloud_watch_logs_log_group_arn: 'test-trail-cw-group-arn-1',
+            cloud_watch_logs_role_arn: 'test-trail-cw-role-arn-1',
+            kms_key_id: 'test-trail-kms-key-1'
+          }
+        ]
+      )
+
+      ct_client.stub_responses(
+        :get_trail_status,
+        is_logging: true,
+        latest_delivery_error: 'test-error-1',
+        latest_notification_error: 'test-notification-error-1',
+        latest_delivery_time: Time.now - (60 * 60 * 23),
+        latest_notification_time: Time.now - (60 * 60 * 23),
+        start_logging_time: Time.now - (60 * 60 * 23),
+        stop_logging_time: Time.now - (60 * 60 * 23),
+        latest_cloud_watch_logs_delivery_error: 'log-delivery-error-1',
+        latest_cloud_watch_logs_delivery_time: Time.now - (60 * 60 * 23),
+        latest_digest_delivery_time: Time.now - (60 * 60 * 23),
+        latest_digest_delivery_error: 'digest-delivery-error-1',
+        latest_delivery_attempt_time: 'delivery-attempt-time-str-1',
+        latest_notification_attempt_time: 'notification-attempt-time-str-1',
+        latest_notification_attempt_succeeded: 'notification-attempt-succeeded-1',
+        latest_delivery_attempt_succeeded: 'deliver-attempt-succeeded-1',
+        time_logging_started: 'time-logging-started-str-1',
+        time_logging_stopped: 'time-logging-stopped-str-1'
+      )
+    end
+
+    it "'get_trail_status' should return without an error" do
+      expect { ct_util.get_trail_status(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'get_trail_status' should return expected value" do
+      expect(ct_util.get_trail_status(ct_util.get_cloud_trail_by_name('test-trail-1'))
+             .latest_delivery_error).to eq 'test-error-1'
+    end
+
+    it "'trail_logging_active?' should return without an error" do
+      expect { ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'trail_logging_active?' should return true" do
+      expect(ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq true
+    end
+
+    it "'hours_since_last_delivery' should return without an error" do
+      expect { ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'hours_since_last_delivery' should return 23" do
+      expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq 23
+    end
+  end
+
+  context 'while get_trail_status is stubbed out with nil latest_delivery_time' do
+    before do
+      ct_client.stub_responses(
+        :describe_trails,
+        trail_list: [
+          {
+            name: 'test-trail-1',
+            s3_bucket_name: 'test-trail-bucket-1',
+            s3_key_prefix: 'test-trail-prefix-1',
+            sns_topic_name: 'test-trail-sns-name-1',
+            sns_topic_arn: 'test-trail-sns-arn-1',
+            include_global_service_events: true,
+            is_multi_region_trail: true,
+            home_region: 'test-trail-region-1',
+            trail_arn: 'arn:aws:cloudtrail:us-east-1:444444444444444:trail/itso',
+            log_file_validation_enabled: true,
+            cloud_watch_logs_log_group_arn: 'test-trail-cw-group-arn-1',
+            cloud_watch_logs_role_arn: 'test-trail-cw-role-arn-1',
+            kms_key_id: 'test-trail-kms-key-1'
+          }
+        ]
+      )
+
+      ct_client.stub_responses(
+        :get_trail_status,
+        is_logging: true,
+        latest_delivery_error: 'test-error-1',
+        latest_notification_error: 'test-notification-error-1',
+        latest_delivery_time: nil,
+        latest_notification_time: Time.now - (60 * 60 * 23),
+        start_logging_time: Time.now - (60 * 60 * 23),
+        stop_logging_time: Time.now - (60 * 60 * 23),
+        latest_cloud_watch_logs_delivery_error: 'log-delivery-error-1',
+        latest_cloud_watch_logs_delivery_time: Time.now - (60 * 60 * 23),
+        latest_digest_delivery_time: Time.now - (60 * 60 * 23),
+        latest_digest_delivery_error: 'digest-delivery-error-1',
+        latest_delivery_attempt_time: 'delivery-attempt-time-str-1',
+        latest_notification_attempt_time: 'notification-attempt-time-str-1',
+        latest_notification_attempt_succeeded: 'notification-attempt-succeeded-1',
+        latest_delivery_attempt_succeeded: 'deliver-attempt-succeeded-1',
+        time_logging_started: 'time-logging-started-str-1',
+        time_logging_stopped: 'time-logging-stopped-str-1'
+      )
+    end
+
+    it "'trail_logging_active?' should return without an error" do
+      expect { ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'trail_logging_active?' should return false" do
+      expect(ct_util.trail_logging_active?(ct_util.get_cloud_trail_by_name('test-trail-1'))).to eq false
+    end
+
+    it "'hours_since_last_delivery' should return without an error" do
+      expect { ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')) }.not_to raise_error
+    end
+
+    it "'hours_since_last_delivery' should return nil" do
+      expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')).nil?).to eq true
+    end
+  end
+end

--- a/spec/cloud_trail_utils_spec.rb
+++ b/spec/cloud_trail_utils_spec.rb
@@ -255,4 +255,96 @@ describe Cucloud::CloudTrailUtils do
       expect(ct_util.hours_since_last_delivery(ct_util.get_cloud_trail_by_name('test-trail-1')).nil?).to eq true
     end
   end
+
+  context 'while describe_config_rules is stubbed out with one cloudtrail rules' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: [
+          {
+            config_rule_name: 'test-rule-1',
+            config_rule_arn: 'test-rule-1-arn',
+            config_rule_id: 'test-rule-1-id',
+            description: 'test-rule-1 description',
+            scope: {
+              compliance_resource_types: ['test-rule-1 resource 1'],
+              tag_key: 'test-rule-1-tag-key',
+              tag_value: 'test-rule-1-tag-value',
+              compliance_resource_id: 'test-rule-1-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'CLOUD_TRAIL_ENABLED',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-1-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          },
+          {
+            config_rule_name: 'test-rule-2',
+            config_rule_arn: 'test-rule-2-arn',
+            config_rule_id: 'test-rule-2-id',
+            description: 'test-rule-2 description',
+            scope: {
+              compliance_resource_types: ['test-rule-2 resource 1'],
+              tag_key: 'test-rule-2-tag-key',
+              tag_value: 'test-rule-2-tag-value',
+              compliance_resource_id: 'test-rule-2-compliance-id'
+            },
+            source: { # required
+              owner: 'AWS', # accepts CUSTOM_LAMBDA, AWS
+              source_identifier: 'OTHER_RULE',
+              source_details: [
+                {
+                  event_source: 'aws.config', # accepts aws.config
+                  message_type: 'ConfigurationItemChangeNotification',
+                  maximum_execution_frequency: 'One_Hour'
+                }
+              ]
+            },
+            input_parameters: 'test-rule-2-input',
+            maximum_execution_frequency: 'One_Hour',
+            config_rule_state: 'ACTIVE'
+          }
+
+        ]
+      )
+    end
+
+    it "'get_config_rules' should return without an error" do
+      expect { ct_util.get_config_rules }.not_to raise_error
+    end
+
+    it "'get_config_rules' should return array len 1" do
+      expect(ct_util.get_config_rules.length).to eq 1
+    end
+
+    it "'get_config_rules' should return expected values" do
+      expect(ct_util.get_config_rules.first.config_rule_name).to eq 'test-rule-1'
+    end
+  end
+
+  context 'while describe_config_rules is stubbed without any rules' do
+    before do
+      cs_client.stub_responses(
+        :describe_config_rules,
+        config_rules: []
+      )
+    end
+
+    it "'get_config_rules' should return without an error" do
+      expect { ct_util.get_config_rules }.not_to raise_error
+    end
+
+    it "'get_config_rules' should return array len 0" do
+      expect(ct_util.get_config_rules.length).to eq 0
+    end
+  end
 end

--- a/spec/config_service_utils_spec.rb
+++ b/spec/config_service_utils_spec.rb
@@ -149,14 +149,6 @@ describe Cucloud::ConfigServiceUtils do
     it "'rule_active?' should return true" do
       expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
     end
-
-    it "'rule_for_cloudtrail?' should return without an error" do
-      expect { cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
-
-    it "'rule_for_cloudtrail?' should return true" do
-      expect(cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
-    end
   end
 
   context 'while describe_config_rules is stubbed out NON-active NON-cloudtrail rule' do
@@ -200,14 +192,6 @@ describe Cucloud::ConfigServiceUtils do
 
     it "'rule_active?' should return false" do
       expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
-    end
-
-    it "'rule_for_cloudtrail?' should return without an error" do
-      expect { cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
-
-    it "'rule_for_cloudtrail?' should return false" do
-      expect(cs_util.rule_for_cloudtrail?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
     end
   end
 

--- a/spec/config_service_utils_spec.rb
+++ b/spec/config_service_utils_spec.rb
@@ -28,7 +28,7 @@ describe Cucloud::ConfigServiceUtils do
     expect(Cucloud::ConfigServiceUtils.get_available_regions.length).to eq 5
   end
 
-  context 'while describe_config_rules is stubbed out with response' do
+  context 'while describe_config_rules is stubbed out with a 2-rule response' do
     before do
       cs_client.stub_responses(
         :describe_config_rules,
@@ -195,7 +195,7 @@ describe Cucloud::ConfigServiceUtils do
     end
   end
 
-  context 'while describe_config_rule_evaluation_status is stubbed out as running in last day' do
+  context 'while describe_config_rule_evaluation_status is stubbed out as running 23 hours ago' do
     before do
       cs_client.stub_responses(
         :describe_config_rules,
@@ -257,16 +257,16 @@ describe Cucloud::ConfigServiceUtils do
       expect(cs_util.get_rule_evaluation_status_by_name('test-rule-1').config_rule_name).to eq 'test-rule-1'
     end
 
-    it "'rule_ran_in_last_day?' should return without an error" do
-      expect { cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+    it "'hours_since_last_run' should return without an error" do
+      expect { cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
-    it "'rule_ran_in_last_day?' should return true" do
-      expect(cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
+    it "'hours_since_last_run' should return 23" do
+      expect(cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1'))).to eq 23
     end
   end
 
-  context 'while describe_config_rule_evaluation_status is stubbed out as running > 24 hours ago' do
+  context 'while describe_config_rule_evaluation_status is stubbed out with nil last invocation' do
     before do
       cs_client.stub_responses(
         :describe_config_rules,
@@ -307,7 +307,7 @@ describe Cucloud::ConfigServiceUtils do
             config_rule_name: 'test-rule-1',
             config_rule_arn: 'test-rule-arn-1',
             config_rule_id: 'test-rule-id-1',
-            last_successful_invocation_time: Time.now - (60 * 60 * 25),
+            last_successful_invocation_time: nil,
             last_failed_invocation_time: Time.now - (60 * 60 * 24),
             last_successful_evaluation_time: Time.now - (60 * 60 * 24),
             last_failed_evaluation_time: Time.now - (60 * 60 * 24),
@@ -320,12 +320,12 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'rule_ran_in_last_day?' should return without an error" do
-      expect { cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+    it "'hours_since_last_run' should return without an error" do
+      expect { cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
     end
 
-    it "'rule_ran_in_last_day?' should return false" do
-      expect(cs_util.rule_ran_in_last_day?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
+    it "'hours_since_last_run' should return nil" do
+      expect(cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')).nil?).to eq true
     end
   end
 

--- a/spec/config_service_utils_spec.rb
+++ b/spec/config_service_utils_spec.rb
@@ -90,20 +90,24 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'get_config_rules' should return without an error" do
-      expect { cs_util.get_config_rules }.not_to raise_error
+    describe '#get_config_rules' do
+      it 'should return without an error' do
+        expect { cs_util.get_config_rules }.not_to raise_error
+      end
+
+      it 'should return a 2 element array' do
+        expect(cs_util.get_config_rules.length).to eq 2
+      end
     end
 
-    it "'get_config_rules' should return a 2 element array" do
-      expect(cs_util.get_config_rules.length).to eq 2
-    end
+    describe '#get_config_rule_by_name' do
+      it 'should return without an error' do
+        expect { cs_util.get_config_rule_by_name('test-rule-1') }.not_to raise_error
+      end
 
-    it "'get_config_rule_by_name' should return without an error" do
-      expect { cs_util.get_config_rule_by_name('test-rule-1') }.not_to raise_error
-    end
-
-    it "'get_config_rule_by_name' should return expected rule (first)" do
-      expect(cs_util.get_config_rule_by_name('test-rule-1').config_rule_arn).to eq 'test-rule-1-arn'
+      it 'should return expected rule (first)' do
+        expect(cs_util.get_config_rule_by_name('test-rule-1').config_rule_arn).to eq 'test-rule-1-arn'
+      end
     end
   end
 
@@ -142,12 +146,14 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'rule_active?' should return without an error" do
-      expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
+    describe '#rule_active?' do
+      it 'should return without an error' do
+        expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+      end
 
-    it "'rule_active?' should return true" do
-      expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
+      it 'should return true' do
+        expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
+      end
     end
   end
 
@@ -186,12 +192,14 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'rule_active?' should return without an error" do
-      expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
+    describe '#rule_active?' do
+      it 'should return without an error' do
+        expect { cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+      end
 
-    it "'rule_active?' should return false" do
-      expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
+      it 'should return false' do
+        expect(cs_util.rule_active?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
+      end
     end
   end
 
@@ -249,20 +257,24 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'get_rule_evaluation_status_by_name' should return without an error" do
-      expect { cs_util.get_rule_evaluation_status_by_name('test-rule-1') }.not_to raise_error
+    describe '#get_rule_evaluation_status_by_name' do
+      it 'should return without an error' do
+        expect { cs_util.get_rule_evaluation_status_by_name('test-rule-1') }.not_to raise_error
+      end
+
+      it 'should return rule w/ expected values' do
+        expect(cs_util.get_rule_evaluation_status_by_name('test-rule-1').config_rule_name).to eq 'test-rule-1'
+      end
     end
 
-    it "'get_rule_evaluation_status_by_name' should return rule w/ expected values" do
-      expect(cs_util.get_rule_evaluation_status_by_name('test-rule-1').config_rule_name).to eq 'test-rule-1'
-    end
+    describe '#hours_since_last_run' do
+      it 'should return without an error' do
+        expect { cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+      end
 
-    it "'hours_since_last_run' should return without an error" do
-      expect { cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
-
-    it "'hours_since_last_run' should return 23" do
-      expect(cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1'))).to eq 23
+      it 'should return 23' do
+        expect(cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1'))).to eq 23
+      end
     end
   end
 
@@ -320,12 +332,14 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'hours_since_last_run' should return without an error" do
-      expect { cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
+    describe '#hours_since_last_run' do
+      it 'should return without an error' do
+        expect { cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+      end
 
-    it "'hours_since_last_run' should return nil" do
-      expect(cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')).nil?).to eq true
+      it 'should return nil' do
+        expect(cs_util.hours_since_last_run(cs_util.get_config_rule_by_name('test-rule-1')).nil?).to eq true
+      end
     end
   end
 
@@ -385,20 +399,24 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'get_rule_compliance_by_name' should return without an error" do
-      expect { cs_util.get_rule_compliance_by_name('test-rule-1') }.not_to raise_error
+    describe '#get_rule_compliance_by_name' do
+      it 'should return without an error' do
+        expect { cs_util.get_rule_compliance_by_name('test-rule-1') }.not_to raise_error
+      end
+
+      it 'should return rule w/ expected values' do
+        expect(cs_util.get_rule_compliance_by_name('test-rule-1').compliance_type).to eq 'COMPLIANT'
+      end
     end
 
-    it "'get_rule_compliance_by_name' should return rule w/ expected values" do
-      expect(cs_util.get_rule_compliance_by_name('test-rule-1').compliance_type).to eq 'COMPLIANT'
-    end
+    describe '#rule_compliant?' do
+      it 'should return without an error' do
+        expect { cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+      end
 
-    it "'rule_compliant?' should return without an error" do
-      expect { cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
-
-    it "'rule_compliant?' should return true" do
-      expect(cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
+      it 'should return true' do
+        expect(cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq true
+      end
     end
   end
 
@@ -458,12 +476,14 @@ describe Cucloud::ConfigServiceUtils do
       )
     end
 
-    it "'rule_compliant?' should return without an error" do
-      expect { cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
-    end
+    describe '#rule_compliant?' do
+      it 'should return without an error' do
+        expect { cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1')) }.not_to raise_error
+      end
 
-    it "'rule_compliant?' should return false" do
-      expect(cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
+      it 'should return false' do
+        expect(cs_util.rule_compliant?(cs_util.get_config_rule_by_name('test-rule-1'))).to eq false
+      end
     end
   end
 end

--- a/spec/iam_utils_spec.rb
+++ b/spec/iam_utils_spec.rb
@@ -27,16 +27,18 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_account_alias' should return without an error" do
-      expect { iam_util.get_account_alias }.not_to raise_error
-    end
+    describe '#get_account_alias' do
+      it 'should return without an error' do
+        expect { iam_util.get_account_alias }.not_to raise_error
+      end
 
-    it "'get_account_alias' should return expected value" do
-      expect(iam_util.get_account_alias).to eq 'test-alias'
-    end
+      it 'should return expected value' do
+        expect(iam_util.get_account_alias).to eq 'test-alias'
+      end
 
-    it "'get_asg_by_name' should return type String" do
-      expect(iam_util.get_account_alias.class.to_s).to eq 'String'
+      it 'should return type String' do
+        expect(iam_util.get_account_alias.class.to_s).to eq 'String'
+      end
     end
   end
 
@@ -49,12 +51,14 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_account_alias' should return without an error" do
-      expect { iam_util.get_account_alias }.not_to raise_error
-    end
+    describe '#get_account_alias' do
+      it 'should return without an error' do
+        expect { iam_util.get_account_alias }.not_to raise_error
+      end
 
-    it "'get_account_alias' should return nil" do
-      expect(iam_util.get_account_alias.nil?).to eq true
+      it 'should return nil' do
+        expect(iam_util.get_account_alias.nil?).to eq true
+      end
     end
   end
 
@@ -69,17 +73,19 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_account_summary' should return without an error" do
-      expect { iam_util.get_account_summary }.not_to raise_error
-    end
+    describe '#get_account_summary' do
+      it 'should return without an error' do
+        expect { iam_util.get_account_summary }.not_to raise_error
+      end
 
-    it "'get_account_summary' return hash should have expected keys/values" do
-      expect(iam_util.get_account_summary['test_key_1']).to eq 1
-      expect(iam_util.get_account_summary['test_key_2']).to eq 2
-    end
+      it 'should return hash should have expected keys/values' do
+        expect(iam_util.get_account_summary['test_key_1']).to eq 1
+        expect(iam_util.get_account_summary['test_key_2']).to eq 2
+      end
 
-    it "'get_account_summary' return nil for key that doesn't exist" do
-      expect(iam_util.get_account_summary['test_key_3'].nil?).to eq true
+      it "should return nil for key that doesn't exist" do
+        expect(iam_util.get_account_summary['test_key_3'].nil?).to eq true
+      end
     end
   end
 
@@ -95,32 +101,40 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_account_summary' should return without an error" do
-      expect { iam_util.get_account_summary }.not_to raise_error
+    describe '#get_account_summary' do
+      it 'should return without an error' do
+        expect { iam_util.get_account_summary }.not_to raise_error
+      end
     end
 
-    it "'root_user_has_api_key?' should return without an error" do
-      expect { iam_util.root_user_has_api_key? }.not_to raise_error
+    describe '#root_user_has_api_key?' do
+      it 'should return without an error' do
+        expect { iam_util.root_user_has_api_key? }.not_to raise_error
+      end
+
+      it 'should return false' do
+        expect(iam_util.root_user_has_api_key?).to eq false
+      end
     end
 
-    it "'root_user_has_api_key?' should return false" do
-      expect(iam_util.root_user_has_api_key?).to eq false
+    describe '#root_user_mfa_enabled?' do
+      it 'should return without an error' do
+        expect { iam_util.root_user_mfa_enabled? }.not_to raise_error
+      end
+
+      it 'should return false' do
+        expect(iam_util.root_user_mfa_enabled?).to eq false
+      end
     end
 
-    it "'root_user_mfa_enabled?' should return without an error" do
-      expect { iam_util.root_user_mfa_enabled? }.not_to raise_error
-    end
+    describe '#multiple_providers_configured?' do
+      it 'should return without an error' do
+        expect { iam_util.multiple_providers_configured? }.not_to raise_error
+      end
 
-    it "'root_user_mfa_enabled?' should return false" do
-      expect(iam_util.root_user_mfa_enabled?).to eq false
-    end
-
-    it "'multiple_providers_configured?' should return without an error" do
-      expect { iam_util.multiple_providers_configured? }.not_to raise_error
-    end
-
-    it "'multiple_providers_configured?' should return false" do
-      expect(iam_util.multiple_providers_configured?).to eq false
+      it 'should return false' do
+        expect(iam_util.multiple_providers_configured?).to eq false
+      end
     end
   end
 
@@ -136,32 +150,40 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_account_summary' should return without an error" do
-      expect { iam_util.get_account_summary }.not_to raise_error
+    describe '#get_account_summary' do
+      it 'should return without an error' do
+        expect { iam_util.get_account_summary }.not_to raise_error
+      end
     end
 
-    it "'root_user_has_api_key?' should return without an error" do
-      expect { iam_util.root_user_has_api_key? }.not_to raise_error
+    describe '#root_user_has_api_key?' do
+      it 'should return without an error' do
+        expect { iam_util.root_user_has_api_key? }.not_to raise_error
+      end
+
+      it 'should return true' do
+        expect(iam_util.root_user_has_api_key?).to eq true
+      end
     end
 
-    it "'root_user_has_api_key?' should return true" do
-      expect(iam_util.root_user_has_api_key?).to eq true
+    describe '#root_user_mfa_enabled?' do
+      it 'should return without an error' do
+        expect { iam_util.root_user_mfa_enabled? }.not_to raise_error
+      end
+
+      it 'should return true' do
+        expect(iam_util.root_user_mfa_enabled?).to eq true
+      end
     end
 
-    it "'root_user_mfa_enabled?' should return without an error" do
-      expect { iam_util.root_user_mfa_enabled? }.not_to raise_error
-    end
+    describe '#multiple_providers_configured?' do
+      it 'should return without an error' do
+        expect { iam_util.multiple_providers_configured? }.not_to raise_error
+      end
 
-    it "'root_user_mfa_enabled?' should return true" do
-      expect(iam_util.root_user_mfa_enabled?).to eq true
-    end
-
-    it "'multiple_providers_configured?' should return without an error" do
-      expect { iam_util.multiple_providers_configured? }.not_to raise_error
-    end
-
-    it "'multiple_providers_configured?' should return true" do
-      expect(iam_util.multiple_providers_configured?).to eq true
+      it 'should return true' do
+        expect(iam_util.multiple_providers_configured?).to eq true
+      end
     end
   end
 
@@ -173,21 +195,24 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_saml_providers' should return without an error" do
-      expect { iam_util.get_saml_providers }.not_to raise_error
+    describe '#get_saml_providers' do
+      it 'should return without an error' do
+        expect { iam_util.get_saml_providers }.not_to raise_error
+      end
+
+      it 'should return empty array' do
+        expect(iam_util.get_saml_providers.empty?).to eq true
+      end
     end
 
-    it "'get_saml_providers should return empty array" do
-      puts iam_util.get_saml_providers
-      expect(iam_util.get_saml_providers.empty?).to eq true
-    end
+    describe '#cornell_provider_configured?' do
+      it 'should return without an error' do
+        expect { iam_util.cornell_provider_configured? }.not_to raise_error
+      end
 
-    it "'cornell_provider_configured?' should return without an error" do
-      expect { iam_util.cornell_provider_configured? }.not_to raise_error
-    end
-
-    it "'cornell_provider_configured?' should return false" do
-      expect(iam_util.cornell_provider_configured?).to eq false
+      it 'should return false' do
+        expect(iam_util.cornell_provider_configured?).to eq false
+      end
     end
   end
 
@@ -213,20 +238,24 @@ describe Cucloud::IamUtils do
       # rubocop:enable Metrics/LineLength
     end
 
-    it "'get_saml_providers' should return without an error" do
-      expect { iam_util.get_saml_providers }.not_to raise_error
+    describe '#get_saml_providers' do
+      it 'should return without an error' do
+        expect { iam_util.get_saml_providers }.not_to raise_error
+      end
+
+      it 'should return non-empty array' do
+        expect(iam_util.get_saml_providers.empty?).to eq false
+      end
     end
 
-    it "'get_saml_providers' should return non-empty array" do
-      expect(iam_util.get_saml_providers.empty?).to eq false
-    end
+    describe '#cornell_provider_configured?' do
+      it 'should return without an error' do
+        expect { iam_util.cornell_provider_configured? }.not_to raise_error
+      end
 
-    it "'cornell_provider_configured?' should return without an error" do
-      expect { iam_util.cornell_provider_configured? }.not_to raise_error
-    end
-
-    it "'cornell_provider_configured?' should return true" do
-      expect(iam_util.cornell_provider_configured?).to eq true
+      it 'should return true' do
+        expect(iam_util.cornell_provider_configured?).to eq true
+      end
     end
   end
 
@@ -251,20 +280,24 @@ describe Cucloud::IamUtils do
       # rubocop:enable Metrics/LineLength
     end
 
-    it "'get_saml_providers' should return without an error" do
-      expect { iam_util.get_saml_providers }.not_to raise_error
+    describe '#get_saml_providers' do
+      it 'should return without an error' do
+        expect { iam_util.get_saml_providers }.not_to raise_error
+      end
+
+      it 'should return non-empty array' do
+        expect(iam_util.get_saml_providers.empty?).to eq false
+      end
     end
 
-    it "'get_saml_providers' should return non-empty array" do
-      expect(iam_util.get_saml_providers.empty?).to eq false
-    end
+    describe '#cornell_provider_configured?' do
+      it 'should return without an error' do
+        expect { iam_util.cornell_provider_configured? }.not_to raise_error
+      end
 
-    it "'cornell_provider_configured?' should return without an error" do
-      expect { iam_util.cornell_provider_configured? }.not_to raise_error
-    end
-
-    it "'cornell_provider_configured?' should return false" do
-      expect(iam_util.cornell_provider_configured?).to eq false
+      it 'should return false' do
+        expect(iam_util.cornell_provider_configured?).to eq false
+      end
     end
   end
 
@@ -276,12 +309,14 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_users' should return without an error" do
-      expect { iam_util.get_users }.not_to raise_error
-    end
+    describe '#get_users' do
+      it 'should return without an error' do
+        expect { iam_util.get_users }.not_to raise_error
+      end
 
-    it "'get_users' should return empty array" do
-      expect(iam_util.get_users.empty?).to eq true
+      it 'should return empty array' do
+        expect(iam_util.get_users.empty?).to eq true
+      end
     end
   end
 
@@ -297,8 +332,10 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'user_has_password?' should return true" do
-      expect(iam_util.user_has_password?('test-user')).to eq true
+    describe '#user_has_password?' do
+      it 'should return true' do
+        expect(iam_util.user_has_password?('test-user')).to eq true
+      end
     end
   end
 
@@ -310,8 +347,10 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'user_has_password?' should return false" do
-      expect(iam_util.user_has_password?('test-user')).to eq false
+    describe '#user_has_password?' do
+      it 'should return false' do
+        expect(iam_util.user_has_password?('test-user')).to eq false
+      end
     end
   end
 
@@ -352,26 +391,28 @@ describe Cucloud::IamUtils do
         )
       end
 
-      it "'get_users' should return without an error" do
-        expect { iam_util.get_users }.not_to raise_error
-      end
+      describe '#get_users' do
+        it 'should return without an error' do
+          expect { iam_util.get_users }.not_to raise_error
+        end
 
-      it "'get_users' should return non-empty array" do
-        expect(iam_util.get_users.empty?).to eq false
-      end
+        it 'should return non-empty array' do
+          expect(iam_util.get_users.empty?).to eq false
+        end
 
-      it "'get_users' should return user struct values for each array element" do
-        expect(iam_util.get_users[0][:base_data].path).to eq 'test-path-1'
-        expect(iam_util.get_users[0][:base_data].user_name).to eq 'test-user-1'
-        expect(iam_util.get_users[0][:base_data].user_id).to eq 'test-id-1'
-        expect(iam_util.get_users[1][:base_data].path).to eq 'test-path-2'
-        expect(iam_util.get_users[1][:base_data].user_name).to eq 'test-user-2'
-        expect(iam_util.get_users[1][:base_data].user_id).to eq 'test-id-2'
-      end
+        it 'should return user struct values for each array element' do
+          expect(iam_util.get_users[0][:base_data].path).to eq 'test-path-1'
+          expect(iam_util.get_users[0][:base_data].user_name).to eq 'test-user-1'
+          expect(iam_util.get_users[0][:base_data].user_id).to eq 'test-id-1'
+          expect(iam_util.get_users[1][:base_data].path).to eq 'test-path-2'
+          expect(iam_util.get_users[1][:base_data].user_name).to eq 'test-user-2'
+          expect(iam_util.get_users[1][:base_data].user_id).to eq 'test-id-2'
+        end
 
-      it "'get_users' has_password key should be true" do
-        expect(iam_util.get_users[0][:has_password]).to eq true
-        expect(iam_util.get_users[1][:has_password]).to eq true
+        it 'has_password key should be true' do
+          expect(iam_util.get_users[0][:has_password]).to eq true
+          expect(iam_util.get_users[1][:has_password]).to eq true
+        end
       end
     end
 
@@ -383,26 +424,28 @@ describe Cucloud::IamUtils do
         )
       end
 
-      it "'get_users' should return without an error" do
-        expect { iam_util.get_users }.not_to raise_error
-      end
+      describe '#get_users' do
+        it 'should return without an error' do
+          expect { iam_util.get_users }.not_to raise_error
+        end
 
-      it "'get_users' should return non-empty array" do
-        expect(iam_util.get_users.empty?).to eq false
-      end
+        it 'should return non-empty array' do
+          expect(iam_util.get_users.empty?).to eq false
+        end
 
-      it "'get_users' should return user struct values for each array element" do
-        expect(iam_util.get_users[0][:base_data].path).to eq 'test-path-1'
-        expect(iam_util.get_users[0][:base_data].user_name).to eq 'test-user-1'
-        expect(iam_util.get_users[0][:base_data].user_id).to eq 'test-id-1'
-        expect(iam_util.get_users[1][:base_data].path).to eq 'test-path-2'
-        expect(iam_util.get_users[1][:base_data].user_name).to eq 'test-user-2'
-        expect(iam_util.get_users[1][:base_data].user_id).to eq 'test-id-2'
-      end
+        it 'should return user struct values for each array element' do
+          expect(iam_util.get_users[0][:base_data].path).to eq 'test-path-1'
+          expect(iam_util.get_users[0][:base_data].user_name).to eq 'test-user-1'
+          expect(iam_util.get_users[0][:base_data].user_id).to eq 'test-id-1'
+          expect(iam_util.get_users[1][:base_data].path).to eq 'test-path-2'
+          expect(iam_util.get_users[1][:base_data].user_name).to eq 'test-user-2'
+          expect(iam_util.get_users[1][:base_data].user_id).to eq 'test-id-2'
+        end
 
-      it "'get_users' has_password key should be false" do
-        expect(iam_util.get_users[0][:has_password]).to eq false
-        expect(iam_util.get_users[1][:has_password]).to eq false
+        it 'has_password key should be false' do
+          expect(iam_util.get_users[0][:has_password]).to eq false
+          expect(iam_util.get_users[1][:has_password]).to eq false
+        end
       end
     end
   end
@@ -415,12 +458,14 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_user_access_keys' should return without an error" do
-      expect { iam_util.get_user_access_keys('test-user') }.not_to raise_error
-    end
+    describe '#get_user_access_keys' do
+      it 'should return without an error' do
+        expect { iam_util.get_user_access_keys('test-user') }.not_to raise_error
+      end
 
-    it "'get_user_access_keys' should return empty array" do
-      expect(iam_util.get_user_access_keys('test-user').empty?).to eq true
+      it 'should return empty array' do
+        expect(iam_util.get_user_access_keys('test-user').empty?).to eq true
+      end
     end
   end
 
@@ -480,49 +525,53 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_user_access_keys' should return without an error" do
-      expect { iam_util.get_user_access_keys('test-user') }.not_to raise_error
+    describe '#get_user_access_keys' do
+      it 'should return without an error' do
+        expect { iam_util.get_user_access_keys('test-user') }.not_to raise_error
+      end
+
+      it 'should return non-empty array' do
+        expect(iam_util.get_user_access_keys('test-user').empty?).to eq false
+      end
+
+      it 'should have original respone data in base_data key' do
+        expect(iam_util.get_user_access_keys('test-user')[0][:base_data].user_name).to eq 'test-user'
+        expect(iam_util.get_user_access_keys('test-user')[0][:base_data].access_key_id).to eq 'test-key-1'
+        expect(iam_util.get_user_access_keys('test-user')[0][:base_data].status).to eq 'Active'
+        expect(iam_util.get_user_access_keys('test-user')[1][:base_data].user_name).to eq 'test-user'
+        expect(iam_util.get_user_access_keys('test-user')[1][:base_data].access_key_id).to eq 'test-key-2'
+        expect(iam_util.get_user_access_keys('test-user')[1][:base_data].status).to eq 'Inactive'
+        expect(iam_util.get_user_access_keys('test-user')[2][:base_data].user_name).to eq 'test-user'
+        expect(iam_util.get_user_access_keys('test-user')[2][:base_data].access_key_id).to eq 'test-key-3'
+        expect(iam_util.get_user_access_keys('test-user')[2][:base_data].status).to eq 'Active'
+        expect(iam_util.get_user_access_keys('test-user')[3][:base_data].user_name).to eq 'test-user'
+        expect(iam_util.get_user_access_keys('test-user')[3][:base_data].access_key_id).to eq 'test-key-4'
+        expect(iam_util.get_user_access_keys('test-user')[3][:base_data].status).to eq 'Active'
+      end
+
+      it 'key age should calculate correctly' do
+        expect(iam_util.get_user_access_keys('test-user')[0][:days_old]).to eq 60
+        expect(iam_util.get_user_access_keys('test-user')[1][:days_old]).to eq 90
+        expect(iam_util.get_user_access_keys('test-user')[2][:days_old]).to eq 120
+        expect(iam_util.get_user_access_keys('test-user')[3][:days_old]).to eq 150
+      end
+
+      it 'active boolean should calculate correctly' do
+        expect(iam_util.get_user_access_keys('test-user')[0][:active]).to eq true
+        expect(iam_util.get_user_access_keys('test-user')[1][:active]).to eq false
+        expect(iam_util.get_user_access_keys('test-user')[2][:active]).to eq true
+        expect(iam_util.get_user_access_keys('test-user')[3][:active]).to eq true
+      end
     end
 
-    it "'get_user_access_keys' should return non-empty array" do
-      expect(iam_util.get_user_access_keys('test-user').empty?).to eq false
-    end
+    describe '#get_active_keys_older_than_n_days' do
+      it 'should return without an error' do
+        expect { iam_util.get_active_keys_older_than_n_days(80) }.not_to raise_error
+      end
 
-    it "'get_user_access_keys' should have original respone data in base_data key" do
-      expect(iam_util.get_user_access_keys('test-user')[0][:base_data].user_name).to eq 'test-user'
-      expect(iam_util.get_user_access_keys('test-user')[0][:base_data].access_key_id).to eq 'test-key-1'
-      expect(iam_util.get_user_access_keys('test-user')[0][:base_data].status).to eq 'Active'
-      expect(iam_util.get_user_access_keys('test-user')[1][:base_data].user_name).to eq 'test-user'
-      expect(iam_util.get_user_access_keys('test-user')[1][:base_data].access_key_id).to eq 'test-key-2'
-      expect(iam_util.get_user_access_keys('test-user')[1][:base_data].status).to eq 'Inactive'
-      expect(iam_util.get_user_access_keys('test-user')[2][:base_data].user_name).to eq 'test-user'
-      expect(iam_util.get_user_access_keys('test-user')[2][:base_data].access_key_id).to eq 'test-key-3'
-      expect(iam_util.get_user_access_keys('test-user')[2][:base_data].status).to eq 'Active'
-      expect(iam_util.get_user_access_keys('test-user')[3][:base_data].user_name).to eq 'test-user'
-      expect(iam_util.get_user_access_keys('test-user')[3][:base_data].access_key_id).to eq 'test-key-4'
-      expect(iam_util.get_user_access_keys('test-user')[3][:base_data].status).to eq 'Active'
-    end
-
-    it "'get_user_access_keys' key age should calculate correctly" do
-      expect(iam_util.get_user_access_keys('test-user')[0][:days_old]).to eq 60
-      expect(iam_util.get_user_access_keys('test-user')[1][:days_old]).to eq 90
-      expect(iam_util.get_user_access_keys('test-user')[2][:days_old]).to eq 120
-      expect(iam_util.get_user_access_keys('test-user')[3][:days_old]).to eq 150
-    end
-
-    it "'get_user_access_keys' active boolean should calculate correctly" do
-      expect(iam_util.get_user_access_keys('test-user')[0][:active]).to eq true
-      expect(iam_util.get_user_access_keys('test-user')[1][:active]).to eq false
-      expect(iam_util.get_user_access_keys('test-user')[2][:active]).to eq true
-      expect(iam_util.get_user_access_keys('test-user')[3][:active]).to eq true
-    end
-
-    it "'get_active_keys_older_than_n_days' should return without an error" do
-      expect { iam_util.get_active_keys_older_than_n_days(80) }.not_to raise_error
-    end
-
-    it "'get_active_keys_older_than_n_days' return 4 keys over 90 days old" do
-      expect(iam_util.get_active_keys_older_than_n_days(80).length).to eq 4
+      it 'should return 4 keys over 90 days old' do
+        expect(iam_util.get_active_keys_older_than_n_days(80).length).to eq 4
+      end
     end
   end
 
@@ -545,107 +594,111 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'get_account_password_policy' should return without an error" do
-      expect { iam_util.get_account_password_policy }.not_to raise_error
+    describe '#get_account_password_policy' do
+      it 'should return without an error' do
+        expect { iam_util.get_account_password_policy }.not_to raise_error
+      end
+
+      it 'should have values of return' do
+        expect(iam_util.get_account_password_policy.minimum_password_length).to eq 20
+        expect(iam_util.get_account_password_policy.require_symbols).to eq false
+        expect(iam_util.get_account_password_policy.require_numbers).to eq true
+        expect(iam_util.get_account_password_policy.require_uppercase_characters).to eq true
+      end
     end
 
-    it "'get_account_password_policy' should have values of return" do
-      expect(iam_util.get_account_password_policy.minimum_password_length).to eq 20
-      expect(iam_util.get_account_password_policy.require_symbols).to eq false
-      expect(iam_util.get_account_password_policy.require_numbers).to eq true
-      expect(iam_util.get_account_password_policy.require_uppercase_characters).to eq true
-    end
+    describe '#audit_password_policy' do
+      it 'should return without an error' do
+        expect { iam_util.audit_password_policy }.not_to raise_error
+      end
 
-    it "'audit_password_policy' should return without an error" do
-      expect { iam_util.audit_password_policy }.not_to raise_error
-    end
+      it 'should return expected results to example test' do
+        audit_example = [
+          {
+            key: 'minimum_password_length',
+            operator: 'GTE',
+            value: 15
+          },
+          {
+            operator: 'EQ',
+            key: 'require_symbols',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'require_numbers',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'require_uppercase_characters',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'require_lowercase_characters',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'allow_users_to_change_password',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'expire_passwords',
+            value: true
+          },
+          {
+            operator: 'LTE',
+            key: 'max_password_age',
+            value: 10
+          },
+          {
+            operator: 'LTE',
+            key: 'password_reuse_prevention',
+            value: 3
+          },
+          {
+            operator: 'EQ',
+            key: 'hard_expiry',
+            value: true
+          }
+        ]
 
-    it "'audit_password_policy' should return expected results to example test" do
-      audit_example = [
-        {
-          key: 'minimum_password_length',
-          operator: 'GTE',
-          value: 15
-        },
-        {
-          operator: 'EQ',
-          key: 'require_symbols',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'require_numbers',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'require_uppercase_characters',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'require_lowercase_characters',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'allow_users_to_change_password',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'expire_passwords',
-          value: true
-        },
-        {
-          operator: 'LTE',
-          key: 'max_password_age',
-          value: 10
-        },
-        {
-          operator: 'LTE',
-          key: 'password_reuse_prevention',
-          value: 3
-        },
-        {
-          operator: 'EQ',
+        expect(iam_util.audit_password_policy(audit_example)[0][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[1][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[2][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[3][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[4][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[5][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[6][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[7][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[8][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[9][:passes]).to eq true
+      end
+
+      it 'should throw UnknownComparisonOperatorError exception on unknown operator' do
+        test_audit = [{
+          operator: 'EQQ',
           key: 'hard_expiry',
           value: true
-        }
-      ]
+        }]
 
-      expect(iam_util.audit_password_policy(audit_example)[0][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[1][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[2][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[3][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[4][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[5][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[6][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[7][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[8][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[9][:passes]).to eq true
-    end
+        expect do
+          iam_util.audit_password_policy(test_audit)
+        end.to raise_error(Cucloud::IamUtils::UnknownComparisonOperatorError)
+      end
 
-    it "'audit_password_policy' should throw UnknownComparisonOperatorError exception on unknown operator" do
-      test_audit = [{
-        operator: 'EQQ',
-        key: 'hard_expiry',
-        value: true
-      }]
+      it 'should fail test if key not found' do
+        audit_example = [{
+          operator: 'EQ',
+          key: 'hard_expiryy',
+          value: true
+        }]
 
-      expect do
-        iam_util.audit_password_policy(test_audit)
-      end.to raise_error(Cucloud::IamUtils::UnknownComparisonOperatorError)
-    end
-
-    it "'audit_password_policy' should fail test if key not found" do
-      audit_example = [{
-        operator: 'EQ',
-        key: 'hard_expiryy',
-        value: true
-      }]
-
-      expect(iam_util.audit_password_policy(audit_example)[0][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[0][:passes]).to eq false
+      end
     end
   end
 
@@ -668,74 +721,76 @@ describe Cucloud::IamUtils do
       )
     end
 
-    it "'audit_password_policy' should return without an error" do
-      expect { iam_util.audit_password_policy }.not_to raise_error
-    end
+    describe '#audit_password_policy' do
+      it 'should return without an error' do
+        expect { iam_util.audit_password_policy }.not_to raise_error
+      end
 
-    it "'audit_password_policy' should fail tests where policy value is nil" do
-      audit_example = [
-        {
-          key: 'minimum_password_length',
-          operator: 'GTE',
-          value: 15
-        },
-        {
-          operator: 'EQ',
-          key: 'require_symbols',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'require_numbers',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'require_uppercase_characters',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'require_lowercase_characters',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'allow_users_to_change_password',
-          value: true
-        },
-        {
-          operator: 'EQ',
-          key: 'expire_passwords',
-          value: true
-        },
-        {
-          operator: 'LTE',
-          key: 'max_password_age',
-          value: 10
-        },
-        {
-          operator: 'LTE',
-          key: 'password_reuse_prevention',
-          value: 3
-        },
-        {
-          operator: 'EQ',
-          key: 'hard_expiry',
-          value: true
-        }
-      ]
+      it 'should fail tests where policy value is nil' do
+        audit_example = [
+          {
+            key: 'minimum_password_length',
+            operator: 'GTE',
+            value: 15
+          },
+          {
+            operator: 'EQ',
+            key: 'require_symbols',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'require_numbers',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'require_uppercase_characters',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'require_lowercase_characters',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'allow_users_to_change_password',
+            value: true
+          },
+          {
+            operator: 'EQ',
+            key: 'expire_passwords',
+            value: true
+          },
+          {
+            operator: 'LTE',
+            key: 'max_password_age',
+            value: 10
+          },
+          {
+            operator: 'LTE',
+            key: 'password_reuse_prevention',
+            value: 3
+          },
+          {
+            operator: 'EQ',
+            key: 'hard_expiry',
+            value: true
+          }
+        ]
 
-      expect(iam_util.audit_password_policy(audit_example)[0][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[1][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[2][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[3][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[4][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[5][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[6][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[7][:passes]).to eq false
-      expect(iam_util.audit_password_policy(audit_example)[8][:passes]).to eq true
-      expect(iam_util.audit_password_policy(audit_example)[9][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[0][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[1][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[2][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[3][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[4][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[5][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[6][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[7][:passes]).to eq false
+        expect(iam_util.audit_password_policy(audit_example)[8][:passes]).to eq true
+        expect(iam_util.audit_password_policy(audit_example)[9][:passes]).to eq true
+      end
     end
   end
 end


### PR DESCRIPTION
Incorporate/refactor cloudtrail functionality from aws-config-check project + add tests.  Updated some test for other utility libraries to use more idiomatic rspec w/ describe blocks.
