### PR TITLE
Flow log check fix

### DIFF
--- a/lib/cucloud/vpc_utils.rb
+++ b/lib/cucloud/vpc_utils.rb
@@ -51,7 +51,21 @@ module Cucloud
     # Does the current region have vpc flow logs?
     # @return [boolean]
     def flow_logs?
-      !@vpc.describe_flow_logs({}).empty?
+      vpc_flow_log_status.find { |x| !x[:flow_logs_active] }.nil?
+    end
+
+    # Does the current region have vpc flow logs?
+    # @return [Array<Hash>]
+    def vpc_flow_log_status
+      puts @vpc.describe_flow_logs.flow_logs
+      @vpc.describe_vpcs.vpcs.map do |vpc|
+        {
+          vpc_id: vpc.vpc_id,
+          flow_logs_active: !@vpc.describe_flow_logs(
+            filter: [{ name: 'resource-id', values: [vpc.vpc_id] }]
+          ).flow_logs.empty?
+        }
+      end
     end
 
     private

--- a/lib/cucloud/vpc_utils.rb
+++ b/lib/cucloud/vpc_utils.rb
@@ -54,7 +54,7 @@ module Cucloud
       vpc_flow_log_status.find { |x| !x[:flow_logs_active] }.nil?
     end
 
-    # Does the current region have vpc flow logs?
+    # Get flow log status for all VPCs in this region
     # @return [Array<Hash>]
     def vpc_flow_log_status
       @vpc.describe_vpcs.vpcs.map do |vpc|

--- a/lib/cucloud/vpc_utils.rb
+++ b/lib/cucloud/vpc_utils.rb
@@ -57,7 +57,6 @@ module Cucloud
     # Does the current region have vpc flow logs?
     # @return [Array<Hash>]
     def vpc_flow_log_status
-      puts @vpc.describe_flow_logs.flow_logs
       @vpc.describe_vpcs.vpcs.map do |vpc|
         {
           vpc_id: vpc.vpc_id,

--- a/spec/vpc_utils_spec.rb
+++ b/spec/vpc_utils_spec.rb
@@ -101,9 +101,107 @@ describe Cucloud::VpcUtils do
     end
   end
 
-  describe '#flow_logs?' do
-    it 'should return true' do
-      expect(vpc_utils.flow_logs?).to be true
+  context 'while vpc responses stubbed out with flow logs enabled' do
+    before do
+      vpc_client.stub_responses(
+        :describe_vpcs,
+        vpcs: [
+          {
+            vpc_id: 'test-vpc',
+            state: 'available',
+            cidr_block: '10.0.0.0/24',
+            dhcp_options_id: 'dopt-1a2b3c4d2',
+            tags: [
+              {
+                key: 'tagname',
+                value: 'tagvalue'
+              }
+            ],
+            instance_tenancy: 'default',
+            is_default: true
+          }
+        ]
+      )
+
+      vpc_client.stub_responses(
+        :describe_flow_logs,
+        flow_logs: [
+          {
+            creation_time: Time.now,
+            flow_log_id: 'test-id',
+            flow_log_status: 'active',
+            resource_id: 'test-vpc',
+            traffic_type: 'ACCEPT',
+            log_group_name: 'log-group',
+            deliver_logs_status: 'active',
+            deliver_logs_error_message: 'test',
+            deliver_logs_permission_arn: 'permission-arn'
+          }
+        ]
+      )
+    end
+
+    describe '#flow_logs?' do
+      it 'should return true' do
+        expect(vpc_utils.flow_logs?).to be true
+      end
+    end
+
+    describe '#vpc_flow_log_status?' do
+      it 'should return expected vpc_id' do
+        expect(vpc_utils.vpc_flow_log_status[0][:vpc_id]).to eq 'test-vpc'
+      end
+
+      it 'should return expected flow log status (true)' do
+        expect(vpc_utils.vpc_flow_log_status[0][:flow_logs_active]).to eq true
+      end
+    end
+  end
+
+  context 'while vpc responses stubbed out without flow logs' do
+    before do
+      vpc_client.stub_responses(
+        :describe_vpcs,
+        vpcs: [
+          {
+            vpc_id: 'test-vpc',
+            state: 'available',
+            cidr_block: '10.0.0.0/24',
+            dhcp_options_id: 'dopt-1a2b3c4d2',
+            tags: [
+              {
+                key: 'tagname',
+                value: 'tagvalue'
+              }
+            ],
+            instance_tenancy: 'default',
+            is_default: true
+          }
+        ]
+      )
+
+      vpc_client.stub_responses(
+        :describe_flow_logs,
+        flow_logs: [
+
+        ]
+      )
+    end
+
+    describe '#flow_logs?' do
+      it 'should return true' do
+        expect(vpc_utils.flow_logs?).to be false
+      end
+    end
+
+    describe '#vpc_flow_log_status?' do
+      it 'should return expected vpc_id' do
+        expect(vpc_utils.vpc_flow_log_status[0][:vpc_id]).to eq 'test-vpc'
+      end
+
+      it 'should return expected flow log status (true)' do
+        expect(vpc_utils.vpc_flow_log_status[0][:flow_logs_active]).to eq false
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #11 - Add new method to get status of flow logs for all VPCs in region.  Update existing flow_logs? method to use this and report true only if all VPCs are logging.  Once in place, the rspec tests in cucloud_ruby_util should be updated to iterate over regions (it currently only checks us-east-1).