### PR TITLE
Resolves CU-CloudCollab/cucloud_ruby#24

### DIFF
--- a/lib/cucloud/ec2_utils.rb
+++ b/lib/cucloud/ec2_utils.rb
@@ -210,7 +210,8 @@ module Cucloud
 
         snapshots_created.push(snapshot_id: snapshot_info.snapshot_id,
                                instance_name: instance_name,
-                               volume: volume.volume_id)
+                               volume: volume.volume_id,
+                               tags: tags)
       end
 
       snapshots_created

--- a/spec/ec2_utils_spec.rb
+++ b/spec/ec2_utils_spec.rb
@@ -31,8 +31,7 @@ describe Cucloud::Ec2Utils do
             { instance_id: 'i-1',
               state: { name: 'running' },
               tags: [
-                { key: 'Name', value: 'example-1' },
-                { key: 'Environment', value: 'test' }
+                { key: 'Name', value: 'example-1' }
               ] }
           ]
         }]
@@ -61,9 +60,6 @@ describe Cucloud::Ec2Utils do
           { volume_id: 'vol-def',
             attachments: [
               instance_id: 'i-1'
-            ],
-            tags: [
-              { key: 'Application', value: 'testapp' }
             ] }
         ]
       )
@@ -82,11 +78,11 @@ describe Cucloud::Ec2Utils do
       expect(Cucloud::Ec2Utils.new).to be_a_kind_of(Cucloud::Ec2Utils)
     end
 
-    it 'dependency injectin ec2_client should be successful' do
+    it 'dependency injection ec2_client should be successful' do
       expect(Cucloud::Ec2Utils.new(ec2_client)).to be_a_kind_of(Cucloud::Ec2Utils)
     end
 
-    it "'get_instances_by_tag' should return '> 1' where tage_name= Name, and tag_value= example-1" do
+    it "'get_instances_by_tag' should return '> 1' where tag_name= Name, and tag_value= example-1" do
       expect(ec_util.get_instances_by_tag('Name', ['example-1']).to_a.size).to eq 1
     end
 
@@ -122,7 +118,7 @@ describe Cucloud::Ec2Utils do
       expect(ec_util.get_instance_name('i-1')).to eq 'example-1'
     end
 
-    it 'should find volumes that have no shapshots in the last five days (default)' do
+    it 'should find volumes that have no snapshots in the last five days (default)' do
       volumes = ec_util.volumes_with_snapshot_within_last_days
       expect(volumes['vol-abc']).to be true
       expect(volumes['vol-def']).to be_nil

--- a/spec/ec2_utils_spec.rb
+++ b/spec/ec2_utils_spec.rb
@@ -126,9 +126,13 @@ describe Cucloud::Ec2Utils do
 
     it 'should backup volumes that do not have a recent snapshot' do
       snapshots_created = ec_util.backup_volumes_unless_recent_backup
-      expect(snapshots_created[0][:snapshot_id]).to eq 'snap-def'
-      expect(snapshots_created[0][:instance_name]).to eq 'example-1'
-      expect(snapshots_created[0][:volume]).to eq 'vol-def'
+      expect(snapshots_created).to match_array(
+        [
+          snapshot_id: 'snap-def',
+          instance_name: 'example-1',
+          volume: 'vol-def'
+        ]
+      )
     end
 
     it 'should create an ebs snapshot' do

--- a/spec/ec2_utils_spec.rb
+++ b/spec/ec2_utils_spec.rb
@@ -31,7 +31,8 @@ describe Cucloud::Ec2Utils do
             { instance_id: 'i-1',
               state: { name: 'running' },
               tags: [
-                { key: 'Name', value: 'example-1' }
+                { key: 'Name', value: 'example-1' },
+                { key: 'Environment', value: 'test'}
               ] }
           ]
         }]
@@ -60,6 +61,9 @@ describe Cucloud::Ec2Utils do
           { volume_id: 'vol-def',
             attachments: [
               instance_id: 'i-1'
+            ],
+            tags: [
+              { key: 'Application', value: 'testapp' }
             ] }
         ]
       )

--- a/spec/ec2_utils_spec.rb
+++ b/spec/ec2_utils_spec.rb
@@ -32,7 +32,7 @@ describe Cucloud::Ec2Utils do
               state: { name: 'running' },
               tags: [
                 { key: 'Name', value: 'example-1' },
-                { key: 'Environment', value: 'test'}
+                { key: 'Environment', value: 'test' }
               ] }
           ]
         }]


### PR DESCRIPTION
Extends backup_volumes_unless_recent_backup to include an array
of tags to preserve from either the EBS volume or EC2 instance.

Primary local purpose is to ensure billing-related tags get passed
from volume/instance to snapshots.